### PR TITLE
Refactor CellTracker with dynamic programming!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache: pip
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install pytest pytest-cov==2.5.1 pytest-pep8 absl-py coveralls
+  - travis_retry pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
 
 script:
   - pytest --cov=deepcell_tracking --pep8

--- a/deepcell_tracking/__init__.py
+++ b/deepcell_tracking/__init__.py
@@ -28,7 +28,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from deepcell_tracking.tracking import cell_tracker
+from deepcell_tracking.tracking import CellTracker
+from deepcell_tracking.tracking import CellTracker as cell_tracker
 from deepcell_tracking import utils
 
 del absolute_import

--- a/deepcell_tracking/__init__.py
+++ b/deepcell_tracking/__init__.py
@@ -29,7 +29,7 @@ from __future__ import division
 from __future__ import print_function
 
 from deepcell_tracking.tracking import CellTracker
-from deepcell_tracking.tracking import CellTracker as cell_tracker
+from deepcell_tracking.tracking import cell_tracker  # alias for old versions
 from deepcell_tracking import utils
 
 del absolute_import

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -609,19 +609,18 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             elif track < number_of_tracks and cell > number_of_cells - 1:
                 continue
 
-        # Cap the tracks of cells that divided
-        number_of_tracks = len(self.tracks)
-        for track in range(number_of_tracks):
-            if self.tracks[track]['daughters'] and not self.tracks[track]['capped']:
+        # Check and make sure cells that divided did not get assigned to the same cell
+        for track in range(len(self.tracks)):
+            if not self.tracks[track]['daughters']:
+                continue  # Filter out cells that have not divided
+
+            # Cap tracks for any divided cells
+            if not self.tracks[track]['capped']:
                 self.tracks[track]['frame_div'] = int(frame)
                 self.tracks[track]['capped'] = True
 
-        # Check and make sure cells that divided did not get assigned to the same cell
-        for track in range(number_of_tracks):
-            if not self.tracks[track]['daughters']:
-                continue
             if frame not in self.tracks[track]['frames']:
-                continue
+                continue  # Filter out tracks that are not in the frame
 
             # Create new track
             old_label = self.tracks[track]['label']

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -495,13 +495,14 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                 continue
 
         # Cap the tracks of cells that divided
-        for track in self.tracks:
+        number_of_tracks = len(self.tracks)
+        for track in range(number_of_tracks):
             if self.tracks[track]['daughters'] and not self.tracks[track]['capped']:
                 self.tracks[track]['frame_div'] = int(frame)
                 self.tracks[track]['capped'] = True
 
         # Check and make sure cells that divided did not get assigned to the same cell
-        for track in self.tracks:
+        for track in range(number_of_tracks):
             if self.tracks[track]['daughters']:
                 if frame in self.tracks[track]['frames']:
                     # Create new track

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -612,9 +612,21 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         return track_neighborhoods
 
     def _sub_area(self, X_frame, y_frame, cell_label, num_channels):
-        true_size = self.neighborhood_true_size
-        pads = ((true_size, true_size),
-                (true_size, true_size),
+        """Fetch a neighborhood surrounding the cell in the given frame.
+
+        Slices out a neighborhood_true_size square region around the center of
+        the provided cell, and reshapes it to neighborhood_scale_size square.
+
+        Args:
+            X_frame (np.array): 2D numpy array, a frame of raw data.
+            y_frame (np.array): 2D numpy array, a frame of annotated data.
+            cell_label (int): The label of the cell to slice out.
+
+        Returns:
+            numpy.array: the resized region of X_frame around cell_label.
+        """
+        pads = ((self.neighborhood_true_size, self.neighborhood_true_size),
+                (self.neighborhood_true_size, self.neighborhood_true_size),
                 (0, 0))
 
         X_padded = np.pad(X_frame, pads, mode='constant', constant_values=0)
@@ -626,8 +638,13 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         center_x, center_y = props[0].centroid
         center_x, center_y = np.int(center_x), np.int(center_y)
 
-        X_reduced = X_padded[center_x - true_size:center_x + true_size,
-                             center_y - true_size:center_y + true_size]
+        x1 = center_x - self.neighborhood_true_size
+        x2 = center_x + self.neighborhood_true_size
+
+        y1 = center_y - self.neighborhood_true_size
+        y2 = center_y + self.neighborhood_true_size
+
+        X_reduced = X_padded[x1:x2, y1:y2]
 
         # resize to neighborhood_scale_size with skimage
         # resize_shape = (2 * self.neighborhood_scale_size + 1,

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -663,25 +663,18 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         Returns:
             int: The parent cell's id or None if no parent exists.
         """
-        # are track_ids 0-something or 1-something??
-        # 0-something because of the `for track_id, p in enumerate(...)` below
-        probs = {}
+        print('New track')
+        parent_id = None
+        max_prob = self.division
         for (track, cell_id), p in predictions.items():
+            prob = p[2]  # probability cell is part of the track
             # Make sure capped tracks can't be assigned parents
             if cell_id == cell and not self.tracks[track]['capped']:
-                probs[track] = p[2]
-
-        # Find out if the cell is a daughter of a track
-        print('New track')
-        max_prob = self.division
-        parent_id = None
-        for track_id, p in probs.items():
-            # we don't want to think a sibling of `cell`, that just appeared
-            # is a parent
-            if self.tracks[track_id]['frames'] == [frame]:
-                continue
-            if p > max_prob:
-                parent_id, max_prob = track_id, p
+                # Do not call a newly-appeared sibling of "cell" a parent
+                if self.tracks[track]['frames'] == [frame]:
+                    continue
+                if prob > max_prob:
+                    parent_id, max_prob = track, prob
         return parent_id
 
     def _sub_area(self, X_frame, y_frame, cell_label):

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -698,9 +698,6 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         neighborhoods = np.zeros(neighborhood_shape, dtype=self.dtype)
         future_areas = np.zeros(future_area_shape, dtype=self.dtype)
         for counter, (frame, cell_label) in enumerate(zip(frames, labels)):
-            # print('Start _get_features for frame {} and label {}'.format(
-            #     frame, cell_label))
-            t = timeit.default_timer()
             # Get the bounding box
             X_frame = X[frame] if self.data_format == 'channels_last' else X[:, frame]
             y_frame = y[frame] if self.data_format == 'channels_last' else y[:, frame]
@@ -725,7 +722,6 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                 resize_shape = (self.crop_dim, self.crop_dim, X.shape[channel_axis])
 
             # Resize images from bounding box
-            t = timeit.default_timer()
             # appearance = resize(appearance, resize_shape, mode="constant", preserve_range=True)
             resize_shape = (self.crop_dim, self.crop_dim)
             appearance = cv2.resize(np.squeeze(appearance), resize_shape)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -154,7 +154,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         self.tracks[new_track]['frame_div'] = None
         self.tracks[new_track]['parent'] = None
 
-        self.tracks[new_track].update(self._get_features(self.x, self.y, [frame], [old_label]))
+        cell_features = self._get_features(self.x, self.y, [frame], [old_label])
+        self.tracks[new_track].update(cell_features)
 
         if frame > 0 and np.any(self.y[frame] == new_label):
             raise Exception('new_label already in annotated frame and frame > 0')

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -47,6 +47,30 @@ from deepcell_tracking.utils import resize
 
 
 class CellTracker(object):  # pylint: disable=useless-object-inheritance
+    """Solves the linear assingment problem to build a cell lineage graph.
+
+    Args:
+        movie (np.array): raw time series movie of cells.
+        annotation (np.array): the labeled cell movie.
+        model (keras.Model): tracking model to determine if two cells are the
+            same, different, or parent/daughter.
+        features (list): list of strings for the features to use.
+        crop_dim (int): crop size for the appearance feature.
+        death (float): paramter used to fill the death matrix in the LAP,
+            (top right of the cost matrix).
+        birth (float): paramter used to fill the birth matrix in the LAP,
+            (bottom left of the cost matrix).
+        division (float): probability threshold for assigning daughter cells.
+        max_distance (int): maximum distance to compare cells with the model.
+        track_length (int): the track length used for the model.
+        neighborhood_scale_size (int): neighborhood feature size to pass to the
+            model.
+        neighborhood_true_size (int): original size of the neighborhood feature
+            which will be scaled down to neighborhood_scale_size.
+        dtype (str): data type for features, can be 'float32', 'float16', etc.
+        data_format (str): determines the order of the channel axis,
+            one of 'channels_first' and 'channels_last'.
+    """
 
     def __init__(self,
                  movie,

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -452,7 +452,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                     # this condition changes `frame_feature`
                     if feature == 'neighborhood':
                         if '~future area' in track_frame_features:
-                            frame_feature = track_frame_features['~future area']
+                            frame_feature = self._get_frame(
+                                track_frame_features['~future area'], 0)
 
                     feature_vals[feature] = (track_feature, frame_feature)
 

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -1171,3 +1171,6 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             print('Error: More than 2 neighbor nodes')
 
         return lineage, tracked
+
+
+cell_tracker = CellTracker  # allow backwards compatibility imports

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -530,9 +530,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         input_pairs, inputs, invalid_pairs = self._get_input_pairs(frame)
 
         t = timeit.default_timer()
-        if not input_pairs:
-            # if the frame is empty
             assignment_matrix[:, :] = 1
+        if not input_pairs:  # frame is empty
             predictions = []
         else:
             model_input = []

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -341,8 +341,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         # Initialize matrices
         number_of_tracks = np.int(len(self.tracks))
 
-        cells_in_frame = np.unique(self.y[frame])
-        cells_in_frame = list(np.delete(cells_in_frame, np.where(cells_in_frame == 0)))
+        cells_in_frame = self.get_cells_in_frame(frame)
         number_of_cells = len(cells_in_frame)
 
         assignment_matrix = np.zeros((number_of_tracks, number_of_cells), dtype=self.dtype)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -689,7 +689,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         return track_neighborhoods
 
-    def _sub_area(self, X_frame, y_frame, cell_label, num_channels):
+    def _sub_area(self, X_frame, y_frame, cell_label):
         """Fetch a neighborhood surrounding the cell in the given frame.
 
         Slices out a neighborhood_true_size square region around the center of

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -229,6 +229,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         new_track_data = {
             'label': new_label,
             'frames': [frame],
+            'frame_labels': [old_label],
             'daughters': [],
             'capped': False,
             'frame_div': None,
@@ -375,7 +376,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             shape = tuple([len(cells_in_frame)] + list(feature_shape))
             frame_features[feature] = np.zeros(shape, dtype=self.dtype)
         # Fill frame_features with the proper values
-        for cell_idx, cell_id in enumerate(cells_in_frame):
+        for cell_idx, cell_id in enumerate(sorted(cells_in_frame)):
             cell_features = self._get_features(frame, cell_id)
             for feature in cell_features:
                 frame_features[feature][cell_idx] = cell_features[feature]
@@ -583,6 +584,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
             if track in self.tracks:  # Add cell and frame to track
                 self.tracks[track]['frames'].append(frame)
+                self.tracks[track]['frame_labels'].append(cell_id)
                 cell_features = self._get_features(frame, cell_id)
                 # cell_features = {f: self.frame_features[f][[cell]]
                 #                  for f in self.frame_features}
@@ -641,6 +643,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
             # Remove features and frame from old track
             del self.tracks[track]['frames'][frame_idx]
+            del self.tracks[track]['frame_labels'][frame_idx]
             for f in self.frame_features:
                 self.tracks[track][f] = np.delete(
                     self.tracks[track][f], frame_idx, axis=0)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -194,21 +194,21 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         """
         This function creates new tracks
         """
-
         new_track = len(self.tracks.keys())
         new_label = new_track + 1
-
-        self.tracks[new_track] = {}
-        self.tracks[new_track]['label'] = new_label
-
-        self.tracks[new_track]['frames'] = [frame]
-        self.tracks[new_track]['daughters'] = []
-        self.tracks[new_track]['capped'] = False
-        self.tracks[new_track]['frame_div'] = None
-        self.tracks[new_track]['parent'] = None
+        new_track_data = {
+            'label': new_label,
+            'frames': [frame],
+            'daughters': [],
+            'capped': False,
+            'frame_div': None,
+            'parent': None,
+        }
 
         cell_features = self._get_features(self.x, self.y, frame, old_label)
-        self.tracks[new_track].update(cell_features)
+        new_track_data.update(cell_features)
+
+        self.tracks[new_track] = new_track_data
 
         if frame > 0 and np.any(self._get_frame(self.y, frame) == new_label):
             raise Exception('new_label already in annotated frame and frame > 0')

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -584,9 +584,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             if track in self.tracks:  # Add cell and frame to track
                 self.tracks[track]['frames'].append(frame)
                 self.tracks[track]['frame_labels'].append(cell_id)
-                cell_features = self._get_features(frame, cell_id)
-                # cell_features = {f: self.frame_features[f][[cell]]
-                #                  for f in self.frame_features}
+                cell_features = {f: self.frame_features[f][[cell]]
+                                 for f in self.frame_features}
                 for feature in cell_features:
                     self.tracks[track][feature] = np.concatenate([
                         self.tracks[track][feature],

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -359,7 +359,6 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         # Compute assignment matrix - Initialize and get model inputs
         # Fill the input matrices
         for track in range(number_of_tracks):
-
             # we need to get the future frame for the track we are comparing to
             try:
                 track_label = self.tracks[track]['label']
@@ -410,8 +409,6 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                 for feature_name, (track_feature, frame_feature) in feature_vals.items():
                     inputs[feature_name][0].append(track_feature)
                     inputs[feature_name][1].append(frame_feature)
-
-        # print('Got features in {}s'.format(timeit.default_timer() - t))
 
         if input_pairs == []:
             # if the frame is empty

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -406,15 +406,14 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         t = timeit.default_timer()  # don't time the other functions
         # Call model.predict only on inputs that are near each other
         inputs = {feature: ([], []) for feature in self.features}
-        input_pairs = []
-        invalid_pairs = []
+        input_pairs, invalid_pairs = [], []
 
         # Fill the input matrices
         for track in range(len(self.tracks)):
             # capped tracks are not allowed to have assignments
             if self.tracks[track]['capped']:
-                invalid_pairs.extend([(track, c)
-                                      for c in range(len(cells_in_frame))])
+                bad_pairs = [(track, c) for c in range(len(cells_in_frame))]
+                invalid_pairs.extend(bad_pairs)
                 continue
 
             # we need to get the future frame for the track we are comparing to

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -282,12 +282,9 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             np.diff(centroids, axis=0)
         ], axis=0)
 
-        is_cell_in_range = True
-        # Make sure the distances are all less than max distance
-        for j in range(distances.shape[0]):  # pylint: disable=E1136
-            if np.linalg.norm(distances[j, :]) > self.max_distance:
-                is_cell_in_range = False
-                break
+        l2 = np.linalg.norm(distances, axis=0)
+        is_cell_in_range = np.all(l2 <= self.max_distance)
+
         return distances[0:-1, :], distances[-1, :], is_cell_in_range
 
     def _fetch_tracked_feature(self, tracks_with_frames, feature):

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -530,9 +530,9 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         input_pairs, inputs, invalid_pairs = self._get_input_pairs(frame)
 
         t = timeit.default_timer()
-            assignment_matrix[:, :] = 1
         if not input_pairs:  # frame is empty
             predictions = []
+            assignment_matrix.fill(1)
         else:
             model_input = []
             for feature in self.features:

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -46,7 +46,7 @@ from skimage.measure import regionprops
 from skimage.transform import resize
 
 
-class cell_tracker(object):  # pylint: disable=useless-object-inheritance
+class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
     def __init__(self,
                  movie,

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -247,8 +247,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         """Intialize the tracks. Tracks are stored in a dictionary.
         """
         frame = 0  # initial frame
-        self.frame_features = self.get_frame_features(frame)
         unique_cells = self.get_cells_in_frame(frame)
+        self.frame_features = self.get_frame_features(frame, unique_cells)
         for cell_label in unique_cells:
             self._create_new_track(frame, cell_label)
 
@@ -347,18 +347,18 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             timeit.default_timer() - t))
         return tracked_features
 
-    def get_frame_features(self, frame):
+    def get_frame_features(self, frame, cells_in_frame):
         """Get all features for each cell in the given frame.
 
         Args:
             frame (int): the frame number to calculate features.
+            cells_in_frame (list): cell_labels in the frame.
 
         Returns:
             dict: dictionary of feature names to feature data
                 for each cell in the frame.
         """
         t = timeit.default_timer()
-        cells_in_frame = self.get_cells_in_frame(frame)
         frame_features = {}
         for feature in self.features:
             feature_shape = self.get_feature_shape(feature)
@@ -390,7 +390,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         track_features = self.fetch_tracked_features()
 
         # Get the features for the current frame
-        self.frame_features = self.get_frame_features(frame)
+        self.frame_features = self.get_frame_features(frame, cells_in_frame)
 
         t = timeit.default_timer()  # don't time the other functions
         # Call model.predict only on inputs that are near each other

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -552,8 +552,18 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         return cost_matrix, dict(zip(input_pairs, predictions))
 
     def _update_tracks(self, assignments, frame, predictions):
-        """Update the tracks if given the assignment matrix
-        and the frame that was tracked.
+        """Update the graph based on the assignment matrix for the frame.
+
+        Use the assignment matrix to determine if each cell in the frame.
+        belongs to a track or is a daughter of a track, and updates the graph
+        accordingly.
+
+        Args:
+            assignments (np.array): completed assignment matrix used to assign
+                cells to existing tracks.
+            frame (int): the frame of cells to assign.
+            predictions (dict): dictionary of trackID-cellID combination,
+                and the probability they are the same cell.
         """
         t = timeit.default_timer()
         cells_in_frame = self.get_cells_in_frame(frame)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -329,8 +329,13 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         return cost_matrix
 
     def _get_cost_matrix(self, frame):
-        """Uses the model to create the cost matrix for
-        assigning the cells in frame to existing tracks.
+        """Use the model predictions to build an assignment matrix to be solved.
+
+        Args:
+            frame (int): The frame with cells to assign.
+
+        Returns:
+            tuple: the assignment matrix and the predictions used to build it.
         """
         t = timeit.default_timer()
         # Initialize matrices

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -225,7 +225,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         frame = 0  # initial frame
         self.frame_features = self.get_frame_features(frame)
         unique_cells = self.get_cells_in_frame(frame)
-        for track_counter, cell_label in enumerate(unique_cells):
+        for cell_label in unique_cells:
             self._create_new_track(frame, cell_label)
 
         # Start a tracked label array

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -252,10 +252,9 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             ok = True
             # Make sure the distances are all less than max distance
             for j in range(distances.shape[0]):
-                dist = distances[j, :]
-                # TODO(enricozb): Finish the distance-based optimizations
-                if np.linalg.norm(dist) > self.max_distance:
+                if np.linalg.norm(distances[j, :]) > self.max_distance:
                     ok = False
+                    break
             return distances[0:-1, :], distances[-1, :], ok
 
         if feature_name == 'neighborhood':

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -542,10 +542,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         else:
             model_input = [ins for f in self.features for ins in inputs[f]]
             predictions = self.model.predict(model_input)
-
             assignment_matrix[list(zip(*input_pairs))] = 1 - predictions[:, 1]
-
-        assignment_matrix[list(zip(*invalid_pairs))] = 1
+            assignment_matrix[list(zip(*invalid_pairs))] = 1
 
         # Assemble full cost matrix
         cost_matrix = self._build_cost_matrix(assignment_matrix)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -346,7 +346,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             fetched = self._fetch_tracked_feature(tracks_with_frames, feature)
             tracked_features[feature] = fetched
 
-        print('Fetched tracked features in {} seconds.'.format(
+        print('Fetched tracked features in {} s.'.format(
             timeit.default_timer() - t))
         return tracked_features
 
@@ -794,9 +794,9 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             assignments = np.stack([row_ind, col_ind], axis=1)
 
             self._update_tracks(assignments, frame, predictions)
-            print('Tracked frame {} in {} seconds.'.format(
+            print('Tracked frame {} in {} s.'.format(
                 frame, timeit.default_timer() - t))
-        print('Tracked all {} frames in {} seconds.'.format(
+        print('Tracked all {} frames in {} s.'.format(
             self.x.shape[self.time_axis], timeit.default_timer() - start))
 
     def _track_review_dict(self):

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -503,30 +503,33 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         # Check and make sure cells that divided did not get assigned to the same cell
         for track in range(number_of_tracks):
-            if self.tracks[track]['daughters']:
-                if frame in self.tracks[track]['frames']:
-                    # Create new track
-                    old_label = self.tracks[track]['label']
-                    new_track_id = len(self.tracks)
-                    new_label = new_track_id + 1
-                    self._create_new_track(frame, old_label)
+            if not self.tracks[track]['daughters']:
+                continue
+            if frame not in self.tracks[track]['frames']:
+                continue
 
-                    for feature_name in self.features:
-                        fname = self.tracks[track][feature_name][[-1]]
-                        self.tracks[new_track_id][feature_name] = fname
+            # Create new track
+            old_label = self.tracks[track]['label']
+            new_track_id = len(self.tracks)
+            new_label = new_track_id + 1
+            self._create_new_track(frame, old_label)
 
-                    self.tracks[new_track_id]['parent'] = track
+            for feature_name in self.features:
+                fname = self.tracks[track][feature_name][[-1]]
+                self.tracks[new_track_id][feature_name] = fname
 
-                    # Remove frame from old track
-                    self.tracks[track]['frames'].remove(frame)
-                    for feature_name in self.features:
-                        fname = self.tracks[track][feature_name][0:-1]
-                        self.tracks[track][feature_name] = fname
-                    self.tracks[track]['daughters'].append(new_track_id)
+            self.tracks[new_track_id]['parent'] = track
 
-                    # Change y_tracked_update
-                    y_tracked_update[self.y[[frame]] == new_label] = new_track_id + 1
-                    self.y[frame][self.y[frame] == new_label] = new_track_id + 1
+            # Remove frame from old track
+            self.tracks[track]['frames'].remove(frame)
+            for feature_name in self.features:
+                fname = self.tracks[track][feature_name][0:-1]
+                self.tracks[track][feature_name] = fname
+            self.tracks[track]['daughters'].append(new_track_id)
+
+            # Change y_tracked_update
+            y_tracked_update[self.y[[frame]] == new_label] = new_track_id + 1
+            self.y[frame][self.y[frame] == new_label] = new_track_id + 1
 
         # Update the tracked label array
         self.y_tracked = np.concatenate([self.y_tracked, y_tracked_update], axis=0)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -181,7 +181,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         """
         cells = np.unique(self._get_frame(self.y, frame))
         cells = np.delete(cells, np.where(cells == 0))  # remove the background
-        return list(cells)
+        return sorted(list(cells))
 
     def get_feature_shape(self, feature_name):
         """Return the shape of the requested feature.

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -362,14 +362,6 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         return cost_matrix, dict(zip(input_pairs, predictions))
 
-    def _run_lap(self, cost_matrix):
-        """Runs the linear assignment function on a cost matrix.
-        """
-        row_ind, col_ind = linear_sum_assignment(cost_matrix)
-        assignments = np.stack([row_ind, col_ind], axis=1)
-
-        return assignments
-
     def _update_tracks(self, assignments, frame, predictions):
         """Update the tracks if given the assignment matrix
         and the frame that was tracked.
@@ -757,7 +749,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
             cost_matrix, predictions = self._get_cost_matrix(frame)
 
-            assignments = self._run_lap(cost_matrix)
+            row_ind, col_ind = linear_sum_assignment(cost_matrix)
+            assignments = np.stack([row_ind, col_ind], axis=1)
 
             self._update_tracks(assignments, frame, predictions)
             print('Tracked frame {} in {} seconds.'.format(

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -542,6 +542,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         else:
             model_input = [ins for f in self.features for ins in inputs[f]]
             predictions = self.model.predict(model_input)
+            # TODO: using tuple (as warning indicates) changes results.
             assignment_matrix[list(zip(*input_pairs))] = 1 - predictions[:, 1]
             assignment_matrix[list(zip(*invalid_pairs))] = 1
 

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -437,7 +437,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         # Assemble full cost matrix
         cost_matrix = self._build_cost_matrix(assignment_matrix)
-
+        print('Built cost matrix for frame {} in {} s.'.format(
+            frame, timeit.default_timer() - t))
         return cost_matrix, dict(zip(input_pairs, predictions))
 
     def _update_tracks(self, assignments, frame, predictions):

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -420,7 +420,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                 # TODO: fetch features from a track in self.tracks
                 track_label = self.tracks[track]['label']
                 track_frame_features = self._get_features(
-                    self.x, self.y_tracked, frame - 1, track_label)
+                    self.x, self.y, frame - 1, track_label)
             except:  # pylint: disable=bare-except
                 # `track_label` might not exist in `frame - 1`
                 # if this happens, default to the cell's neighborhood

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -533,8 +533,15 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
     def _get_parent(self, frame, cell, predictions):
         """Searches the tracks for the parent of a given cell.
+
+        Args:
+            frame (int): the frame the cell appears in.
+            cell (int): the label of the cell in the frame.
+            predictions (dict): dictionary of trackID-cellID combination,
+                and the probability they are the same cell.
+
         Returns:
-            The parent cell's id or None if no parent exists.
+            int: The parent cell's id or None if no parent exists.
         """
         # are track_ids 0-something or 1-something??
         # 0-something because of the `for track_id, p in enumerate(...)` below

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -137,6 +137,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         # Clean up annotations
         self._clean_up_annotations()
 
+        self._track_cells = self.track_cells  # backwards compatibility
+
         # Initialize tracks
         self._initialize_tracks()
 
@@ -801,7 +803,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             '~future area': np.expand_dims(future_area, axis=0)
         }
 
-    def _track_cells(self):
+    def track_cells(self):
         """Tracks all of the cells in every frame.
         """
         for frame in range(1, self.x.shape[0]):

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -265,7 +265,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                 track_label = self.tracks[track]['label']
                 track_frame_features = self._get_features(
                     self.x, self.y_tracked, [frame - 1], [track_label])
-            except:
+            except:  # pylint: disable=bare-except
                 # `track_label` might not exist in `frame - 1`
                 # if this happens, default to the cell's neighborhood
                 track_frame_features = dict()

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -620,7 +620,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         X_padded = np.pad(X_frame, pads, mode='constant', constant_values=0)
         y_padded = np.pad(y_frame, pads, mode='constant', constant_values=0)
 
-        props = regionprops(np.squeeze(np.int32(y_padded == cell_label)))
+        roi = (y_padded == cell_label).astype('int32')
+        props = regionprops(np.squeeze(roi), coordinates='rc')
 
         center_x, center_y = props[0].centroid
         center_x, center_y = np.int(center_x), np.int(center_y)
@@ -686,7 +687,9 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             # Get the bounding box
             X_frame = X[frame] if self.data_format == 'channels_last' else X[:, frame]
             y_frame = y[frame] if self.data_format == 'channels_last' else y[:, frame]
-            props = regionprops(np.squeeze(np.int32(y_frame == cell_label)))
+
+            roi = (y_frame == cell_label).astype('int32')
+            props = regionprops(np.squeeze(roi), coordinates='rc')
 
             minr, minc, maxr, maxc = props[0].bbox
             centroids[counter] = props[0].centroid

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -360,10 +360,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         cost_matrix[0:number_of_tracks, number_of_cells:] = death_matrix
         cost_matrix[number_of_tracks:, number_of_cells:] = mordor_matrix
 
-        predictions_map = {pair: prediction
-                           for pair, prediction in zip(input_pairs, predictions)}
-
-        return cost_matrix, predictions_map
+        return cost_matrix, dict(zip(input_pairs, predictions))
 
     def _run_lap(self, cost_matrix):
         """Runs the linear assignment function on a cost matrix.

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -322,7 +322,6 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                 frames = frames + [frames[-1]] * num_missing
 
             # Get the feature data from the identified frames
-            # TODO: do this without a list comprehension?
             fetched = self.tracks[n][feature][[frame_dict[f] for f in frames]]
             tracked_feature[i] = fetched
         return tracked_feature

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -418,11 +418,10 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
             # we need to get the future frame for the track we are comparing to
             try:
-                # TODO: fetch features from a track in self.tracks
-                track_label = self.tracks[track]['label']
-                track_frame_features = self._get_features(frame - 1, track_label)
-            except:  # pylint: disable=bare-except
-                # `track_label` might not exist in `frame - 1`
+                frame_idx = self.tracks[track]['frames'].index(frame - 1)
+                track_frame_features = {f: self.tracks[track][f][[frame_idx]]
+                                        for f in self.frame_features}
+            except ValueError:  # track may not exist in previous frame
                 # if this happens, default to the cell's neighborhood
                 track_frame_features = dict()
 

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -818,7 +818,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                            for _, track in self.tracks.items()},
                 'X': self.x,
                 'y': self.y,
-                'y_tracked': self.y}
+                'y_tracked': self.y_tracked}
 
     def dataframe(self, **kwargs):
         """Returns a dataframe of the tracked cells with lineage.

--- a/deepcell_tracking/tracking_test.py
+++ b/deepcell_tracking/tracking_test.py
@@ -163,7 +163,7 @@ class TestTracking(parameterized.TestCase):
                     features=[feature_name])
 
                 axis = tracker.channel_axis
-                feature_shape = tracker.feature_shape[feature_name]
+                feature_shape = tracker.get_feature_shape(feature_name)
 
                 feature = tracker._fetch_track_feature(feature_name)
                 assert feature.shape[axis] == feature_shape[axis]
@@ -200,5 +200,5 @@ class TestTracking(parameterized.TestCase):
                     yf = y[f]
 
                     sub = tracker._sub_area(xf, yf, 1)
-
-                    assert sub.shape == tracker.feature_shape['neighborhood']
+                    expected_shape = tracker.get_feature_shape('neighborhood')
+                    assert sub.shape == expected_shape

--- a/deepcell_tracking/tracking_test.py
+++ b/deepcell_tracking/tracking_test.py
@@ -83,29 +83,29 @@ class TestTracking(parameterized.TestCase):
         num_objects = len(np.unique(y)) - 1
         model = DummyModel()
 
-        _ = tracking.cell_tracker(x, y, model=model)
+        _ = tracking.CellTracker(x, y, model=model)
 
         # test data with bad rank
         with pytest.raises(ValueError):
-            tracking.cell_tracker(
+            tracking.CellTracker(
                 np.random.random((32, 32, 1)),
                 np.random.randint(num_objects, size=(32, 32, 1)),
                 model=model)
 
         # test mismatched x and y shape
         with pytest.raises(ValueError):
-            tracking.cell_tracker(
+            tracking.CellTracker(
                 np.random.random((3, 32, 32, 1)),
                 np.random.randint(num_objects, size=(2, 32, 32, 1)),
                 model=model)
 
         # test bad features
         with pytest.raises(ValueError):
-            tracking.cell_tracker(x, y, model=model, features=None)
+            tracking.CellTracker(x, y, model=model, features=None)
 
         # test bad data_format
         with pytest.raises(ValueError):
-            tracking.cell_tracker(x, y, model=model, data_format='invalid')
+            tracking.CellTracker(x, y, model=model, data_format='invalid')
 
     def test__track_cells(self):
         length = 128
@@ -120,7 +120,7 @@ class TestTracking(parameterized.TestCase):
             x, y = _get_dummy_tracking_data(
                 length, frames=frames, data_format=data_format)
 
-            tracker = tracking.cell_tracker(
+            tracker = tracking.CellTracker(
                 x, y,
                 model=DummyModel(),
                 track_length=track_length,
@@ -155,7 +155,7 @@ class TestTracking(parameterized.TestCase):
                 length, frames=frames, data_format=data_format)
 
             for track_length in (1, frames // 2 + 1, frames + 1):
-                tracker = tracking.cell_tracker(
+                tracker = tracking.CellTracker(
                     x, y,
                     model=DummyModel(),
                     track_length=track_length,
@@ -188,7 +188,7 @@ class TestTracking(parameterized.TestCase):
             x, y = _get_dummy_tracking_data(
                 length, frames=frames, data_format=data_format)
 
-            tracker = tracking.cell_tracker(
+            tracker = tracking.CellTracker(
                 x, y, model=model, data_format=data_format)
 
             for f in range(frames):
@@ -199,7 +199,6 @@ class TestTracking(parameterized.TestCase):
                     xf = x[f]
                     yf = y[f]
 
-                    sub = tracker._sub_area(
-                        xf, yf, 1, x.shape[tracker.channel_axis])
+                    sub = tracker._sub_area(xf, yf, 1)
 
                     assert sub.shape == tracker.feature_shape['neighborhood']

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -36,32 +36,57 @@ import tarfile
 import tempfile
 from io import BytesIO
 
+import cv2
 import numpy as np
+from skimage import transform
 
 
-def sorted_nicely(l):
-    """Sort a list of strings by the numerical order of all substrings
+def resize(data, shape, data_format='channels_last'):
+    """Resize the data to the given shape.
+
+    Uses openCV to resize the data if the data is a single channel, as it
+    is very fast. However, openCV does not support multi-channel resizing,
+    so if the data has multiple channels, use skimage.
 
     Args:
-        l (list): List of strings to sort
+        data (np.array): data to be reshaped.
+        shape (tuple): shape of the output data.
+        data_format (str): determines the order of the channel axis,
+            one of 'channels_first' and 'channels_last'.
 
     Returns:
-        list: a sorted list
+        numpy.array: data reshaped to new shape.
     """
-    convert = lambda text: int(text) if text.isdigit() else text
-    alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
-    return sorted(l, key=alphanum_key)
+    # cv2 resize is faster but does not support multi-channel data
+    # If the data is multi-channel, use skimage.transform.resize
+    channel_axis = 0 if data_format == 'channels_first' else -1
+    if data.shape[channel_axis] > 1:  # multichannel data, use skimage
+        # resize with skimage
+        if data_format == 'channels_first':
+            shape = tuple([data.shape[channel_axis]] + list(shape))
+        else:
+            shape = tuple(list(shape) + [data.shape[channel_axis]])
+        resized = transform.resize(data, shape,
+                                   mode='constant',
+                                   preserve_range=True)
+    else:  # single channel image, resize with cv2
+        resized = cv2.resize(np.squeeze(data), shape)  # pytest: disable=E1101
+        resized = np.expand_dims(resized, axis=channel_axis)
+
+    return resized
 
 
 def count_pairs(y, same_probability=0.5, data_format='channels_last'):
     """Compute number of training samples needed to observe all cell pairs.
 
     Args:
-        y (numpy.array): 5D tensor of cell labels
-        same_probability (float): liklihood that 2 cells are the same
+        y (np.array): 5D tensor of cell labels.
+        same_probability (float): liklihood that 2 cells are the same.
+        data_format (str): determines the order of the channel axis,
+            one of 'channels_first' and 'channels_last'.
 
     Returns:
-        int: the total pairs needed to sample to see all possible pairings
+        int: the total pairs needed to sample to see all possible pairings.
     """
     total_pairs = 0
     zaxis = 2 if data_format == 'channels_first' else 1
@@ -100,10 +125,10 @@ def load_trks(filename):
     """Load a trk/trks file.
 
     Args:
-        trks_file (str): full path to the file including .trk/.trks
+        filename (str): full path to the file including .trk/.trks.
 
     Returns:
-        dict: A dictionary with raw, tracked, and lineage data
+        dict: A dictionary with raw, tracked, and lineage data.
     """
     with tarfile.open(filename, 'r') as trks:
 
@@ -144,15 +169,17 @@ def trk_folder_to_trks(dirname, trks_filename):
     """Compiles a directory of trk files into one trks_file.
 
     Args:
-        dirname (str): full path to the directory containing multiple trk files
-        trks_filename (str): desired filename (the name should end in .trks)
+        dirname (str): full path to the directory containing multiple trk files.
+        trks_filename (str): desired filename (the name should end in .trks).
     """
     lineages = []
     raw = []
     tracked = []
 
+    convert = lambda text: int(text) if text.isdigit() else text
+    alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
     file_list = os.listdir(dirname)
-    file_list_sorted = sorted_nicely(file_list)
+    file_list_sorted = sorted(file_list, key=alphanum_key)
 
     for filename in file_list_sorted:
         trk = load_trks(os.path.join(dirname, filename))
@@ -169,10 +196,13 @@ def save_trks(filename, lineages, raw, tracked):
     """Saves raw, tracked, and lineage data into one trks_file.
 
     Args:
-        filename (str): full path to the final trk files
-        lineages (dict[]): a list of dictionaries saved as a json
-        raw (numpy.array): raw images data
-        tracked (numpy.array): annotated image data
+        filename (str): full path to the final trk files.
+        lineages (dict): a list of dictionaries saved as a json.
+        raw (np.array): raw images data.
+        tracked (np.array): annotated image data.
+
+    Raises:
+        ValueError: filename does not end in ".trks".
     """
     if not str(filename).lower().endswith('.trks'):
         raise ValueError('filename must end with `.trks`. Found %s' % filename)
@@ -194,14 +224,14 @@ def save_trks(filename, lineages, raw, tracked):
             trks.add(tracked_file.name, 'tracked.npy')
 
 
-def trks_stats(trks_file_name):
+def trks_stats(filename):
     """For a given trks_file, find the Number of cell tracks,
        the Number of frames per track, and the Number of divisions.
 
     Args:
-        filename (str): full path to a trks file
+        filename (str): full path to a trks file.
     """
-    training_data = load_trks(trks_file_name)
+    training_data = load_trks(filename)
     X = training_data['X']
     y = training_data['y']
     daughters = [{cell: fields['daughters']

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -230,7 +230,15 @@ def trks_stats(filename):
 
     Args:
         filename (str): full path to a trks file.
+
+    Raises:
+        ValueError: filename is not a .trk or .trks file.
     """
+    ext = os.path.splitext(filename)[-1].lower()
+    if ext not in {'.trks', '.trk'}:
+        raise ValueError('`trks_stats` expects a .trk or .trks but found a ' +
+                         str(ext))
+
     training_data = load_trks(filename)
     X = training_data['X']
     y = training_data['y']

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -42,15 +42,21 @@ def _get_image(img_h=300, img_w=300):
 
 class TestTrackingUtils(object):
 
-    def test_sorted_nicely(self):
-        # test image file sorting
-        expected = ['test_001_dapi', 'test_002_dapi', 'test_003_dapi']
-        unsorted = ['test_003_dapi', 'test_001_dapi', 'test_002_dapi']
-        np.testing.assert_array_equal(expected, utils.sorted_nicely(unsorted))
-        # test montage folder sorting
-        expected = ['test_0_0', 'test_1_0', 'test_1_1']
-        unsorted = ['test_1_1', 'test_0_0', 'test_1_0']
-        np.testing.assert_array_equal(expected, utils.sorted_nicely(unsorted))
+    def test_resize(self):
+        channel_sizes = (3, 1)  # skimage used for multi-channel, cv2 otherwise
+        for c in channel_sizes:
+            for data_format in ('channels_last', 'channels_first'):
+                channel_axis = 2 if data_format == 'channels_last' else 0
+                img = np.stack([_get_image()] * c, axis=channel_axis)
+
+                resize_shape = (28, 28)
+                resized_img = utils.resize(img, resize_shape,
+                                           data_format=data_format)
+
+                if data_format == 'channels_first':
+                    assert resized_img.shape[1:] == resize_shape
+                else:
+                    assert resized_img.shape[:-1] == resize_shape
 
     def test_count_pairs(self):
         batches = 1

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(name='Deepcell_Tracking',
       extras_require={
           'tests': ['pytest',
                     'pytest-pep8',
-                    'pytest-cov',
-                    'absl-py'],
+                    'pytest-cov'],
       },
       packages=find_packages())


### PR DESCRIPTION
The `CellTracker` makes far too many `get_features` calls.  By using dynamic programming, and caching each set of features, we can greatly reduce the time to track cells.  Lots of other refactoring went into these changes, including:

* Adding a logger instead of print.
* DRY out the `fetch` functions.
* Replace `feature_shape` dictionary with `get_feature_shape` method.
* Add all features to new track OUTSIDE of `create_new_track`.
* Replace `compute_feature` with `compute_distance` as it was not useful for any other feature.
* Split out `_get_cost_matrix` into several helper functions including `_build_cost_matrix` and `_get_input_pairs`.
* Add utils.resize to replace the skimage/cv2 differences.
* `get_features` is hard-coded for `self.x` and `self.y` and no longer accepts lists of frames or labels.
* Remove dependency on `absl`.