### PR TITLE
Fixed lineage bug in ISBI formatted txt files

### DIFF
--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -169,6 +169,7 @@ def txt_to_graph(path):
         if source not in all_ids:  # parents should be in the previous frame.
             # parent_frame = df[df['Cell_ID'] == row['Parent_id']]['End']
             # source = '{}_{}'.format(row['Parent_ID'], parent_frame)
+            print('%s: skipped parent %s to daughter %s' % (path, source, row['Cell_ID']))
             continue
 
         target = '{}_{}'.format(row['Cell_ID'], row['Start'])
@@ -180,6 +181,7 @@ def txt_to_graph(path):
 
         attributes[source] = {'division': True}
 
+    # Create graph
     G = nx.from_pandas_edgelist(edges, source='source', target='target',
                                 create_using=nx.DiGraph)
     nx.set_node_attributes(G, attributes)
@@ -231,7 +233,7 @@ def classify_divisions(G_gt, G_res):
                     err_msg += 'parents mismatch, '
                 if G_res.out_degree(node) == G_gt.out_degree(node):
                     err_msg += 'gt and res degree equal.'
-                print(err_msg)
+                print(node, err_msg)
 
             div_res.remove(node)
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -195,16 +195,15 @@ def classify_divisions(G_gt, G_res):
                 correct += 1
 
             else:  # what went wrong?
-                if Counter(succ_gt) != Counter(succ_res):
-                    print('daughters mismatch, out degree',
-                          G_res.out_degree(node))
-                if Counter(pred_gt) != Counter(pred_res):
-                    print('parents mismatch, in degree',
-                          G_res.in_degree(node))
-                if G_res.out_degree(node) == G_gt.out_degree(node):
-                    print('parent and daughter mismatch, but degree equal at',
-                          G_res.out_degree(node))
                 incorrect += 1
+                err_msg = 'out degree = {}, '.format(G_res.out_degree(node))
+                if Counter(succ_gt) != Counter(succ_res):
+                    err_msg += 'daughters mismatch, '
+                if Counter(pred_gt) != Counter(pred_res):
+                    err_msg += 'parents mismatch, '
+                if G_res.out_degree(node) == G_gt.out_degree(node):
+                    err_msg += 'gt and res degree equal.'
+                print(err_msg)
 
             div_res.remove(node)
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -186,7 +186,8 @@ def txt_to_graph(path):
         attributes[source] = {'division': True}
 
     # Create graph
-    G = nx.from_pandas_edgelist(edges, source='source', target='target')
+    G = nx.from_pandas_edgelist(edges, source='source', target='target',
+                                create_using=nx.DiGraph)
     nx.set_node_attributes(G, attributes)
     return G
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -246,7 +246,7 @@ def classify_divisions(G_gt, G_res):
             div_res.remove(node)
 
         else:  # valid division not in results, it was missed
-            print('missed division completely')
+            print('missed node {} division completely'.format(node))
             missed += 1
 
     # Count any remaining res nodes as false positives

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -174,10 +174,10 @@ def classify_divisions(G_gt, G_res):
     div_res = [node for node, d in G_res.nodes(data=True)
                if d.get('division', False)]
 
-    correct = 0          # Correct division
-    incorrect = 0        # Wrong division
-    false_positive = 0   # False positive division
-    missed = 0           # Missed division
+    correct = 0         # Correct division
+    incorrect = 0       # Wrong division
+    false_positive = 0  # False positive division
+    missed = 0          # Missed division
 
     for node in div_gt:
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -211,7 +211,7 @@ def classify_divisions(G_gt, G_res):
 
         # Check if res node was also called a division
         if node in div_res:
-            nb_res = list(G_gt.neighbors(node))
+            nb_res = list(G_res.neighbors(node))
             # If neighbors are same, then correct division
             if Counter(nb_gt) == Counter(nb_res):
                 divI += 1

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -131,23 +131,17 @@ def create_new_ISBI_track(batch_tracked, batch_info, old_label,
     return batch_info, batch_tracked
 
 
-def txt_to_graph(path, node_key=None):
+def txt_to_graph(path):
     """Read the ISBI text file and create a Graph.
 
     Args:
         path (str): Path to the ISBI text file.
-        node_key (str, optional): Key to identify the parent/daughter links.
-            (defaults to Cell_ID+Parent_ID)
 
     Returns:
         networkx.Graph: Graph representation of the text file.
     """
     names = ['Cell_ID', 'Start', 'End', 'Parent_ID']
     df = pd.read_csv(path, header=None, sep=' ', names=names)
-
-    if node_key is not None:
-        df[['Cell_ID', 'Parent_ID']] = df[['Cell_ID', 'Parent_ID']].replace(
-            node_key)
 
     edges = pd.DataFrame()
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -36,6 +36,34 @@ import numpy as np
 import pandas as pd
 
 
+def trk_to_isbi(track, path):
+    """Convert a lineage track into an ISBI formatted text file.
+
+    Args:
+        track (dict): Cell lineage object.
+        path (str): Path to save the .txt file.
+    """
+    with open(path, 'w') as text_file:
+        for label in track:
+            first_frame = min(track[label]['frames'])
+            last_frame = max(track[label]['frames'])
+            parent = track[label]['parent']
+            parent = 0 if parent is None else parent
+            if parent:
+                parent_frames = track[parent]['frames']
+                if parent_frames[-1] != first_frame - 1:
+                    parent = 0
+
+            line = '{cell_id} {start} {end} {parent}\n'.format(
+                cell_id=label,
+                start=first_frame,
+                end=last_frame,
+                parent=parent
+            )
+
+            text_file.write(line)
+
+
 def contig_tracks(label, batch_info, batch_tracked):
     """Check for contiguous tracks (tracks should only consist of consecutive frames).
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -214,24 +214,37 @@ def classify_divisions(G_gt, G_res):
     divGH = 0  # Missed division
 
     for node in div_gt:
-        nb_gt = list(G_gt.neighbors(node))
+
+        pred_gt = list(G_gt.pred[node])
+        succ_gt = list(G_gt.succ[node])
 
         # Check if res node was also called a division
         if node in div_res:
-            nb_res = list(G_res.neighbors(node))
-            # If neighbors are same, then correct division
-            if Counter(nb_gt) == Counter(nb_res):
+            pred_res = list(G_gt.pred[node])
+            succ_res = list(G_res.succ[node])
+
+            # Parents and daughters are the same, perfect!
+            if (Counter(pred_gt) == Counter(pred_res) and
+                    Counter(succ_gt) == Counter(succ_res)):
                 divI += 1
-            # Wrong division
-            elif len(nb_res) == 3:
-                divJ += 1
+
             else:
-                divGH += 1
+                if Counter(succ_gt) != Counter(succ_res):
+                    print('daughters mismatch, out degree',
+                          G_res.out_degree(node))
+                if Counter(pred_gt) != Counter(pred_res):
+                    print('parents mismatch, in degree',
+                          G_res.in_degree(node))
+                if G_res.out_degree(node) == G_gt.out_degree(node):
+                    print('parent and daughter mismatch, but degree equal at',
+                          G_res.out_degree(node))
+                divJ += 1
 
             div_res.remove(node)
 
         # If not called division, then missed division
         else:
+            print('missed division completely')
             divGH += 1
 
     # Count any remaining res nodes as false positives

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -234,14 +234,14 @@ def classify_divisions(G_gt, G_res):
 
             else:  # what went wrong?
                 incorrect += 1
-                err_msg = 'out degree = {}, '.format(G_res.out_degree(node))
+                errors = ['out degree = {}'.format(G_res.out_degree(node))]
                 if Counter(succ_gt) != Counter(succ_res):
-                    err_msg += 'daughters mismatch, '
+                    errors.append('daughters mismatch')
                 if Counter(pred_gt) != Counter(pred_res):
-                    err_msg += 'parents mismatch, '
+                    errors.append('parents mismatch')
                 if G_res.out_degree(node) == G_gt.out_degree(node):
-                    err_msg += 'gt and res degree equal.'
-                print(node, err_msg)
+                    errors.append('gt and res degree equal')
+                print(node, '{}.'.format(', '.join(errors)))
 
             div_res.remove(node)
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -152,7 +152,6 @@ def txt_to_graph(path):
 
         attributes[source] = {'division': True}
 
-    # Create graph
     G = nx.from_pandas_edgelist(edges, source='source', target='target',
                                 create_using=nx.DiGraph)
     nx.set_node_attributes(G, attributes)
@@ -175,10 +174,10 @@ def classify_divisions(G_gt, G_res):
     div_res = [node for node, d in G_res.nodes(data=True)
                if d.get('division', False)]
 
-    divI = 0   # Correct division
-    divJ = 0   # Wrong division
-    divC = 0   # False positive division
-    divGH = 0  # Missed division
+    correct = 0          # Correct division
+    incorrect = 0        # Wrong division
+    false_positive = 0   # False positive division
+    missed = 0           # Missed division
 
     for node in div_gt:
 
@@ -193,9 +192,9 @@ def classify_divisions(G_gt, G_res):
             # Parents and daughters are the same, perfect!
             if (Counter(pred_gt) == Counter(pred_res) and
                     Counter(succ_gt) == Counter(succ_res)):
-                divI += 1
+                correct += 1
 
-            else:
+            else:  # what went wrong?
                 if Counter(succ_gt) != Counter(succ_res):
                     print('daughters mismatch, out degree',
                           G_res.out_degree(node))
@@ -205,21 +204,20 @@ def classify_divisions(G_gt, G_res):
                 if G_res.out_degree(node) == G_gt.out_degree(node):
                     print('parent and daughter mismatch, but degree equal at',
                           G_res.out_degree(node))
-                divJ += 1
+                incorrect += 1
 
             div_res.remove(node)
 
-        # If not called division, then missed division
-        else:
+        else:  # valid division not in results, it was missed
             print('missed division completely')
-            divGH += 1
+            missed += 1
 
     # Count any remaining res nodes as false positives
-    divC += len(div_res)
+    false_positive += len(div_res)
 
     return {
-        'Correct division': divI,
-        'Incorrect division': divJ,
-        'False positive division': divC,
-        'False negative division': divGH
+        'Correct division': correct,
+        'Incorrect division': incorrect,
+        'False positive division': false_positive,
+        'False negative division': missed
     }

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -220,15 +220,12 @@ def classify_divisions(G_gt, G_res):
                 divJ += 1
             else:
                 divGH += 1
+
+            div_res.remove(node)
+
         # If not called division, then missed division
         else:
             divGH += 1
-
-        # Remove processed nodes from res list
-        try:
-            div_res.remove(node)
-        except:
-            print('attempted removal of node {} failed'.format(node))
 
     # Count any remaining res nodes as false positives
     divC += len(div_res)

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -150,7 +150,7 @@ def txt_to_graph(path):
 
     all_ids = set()
 
-    # Add each cell lineage as a set of edges to df
+    # Add each continuous cell lineage as a set of edges to df
     for _, row in df.iterrows():
         tpoints = np.arange(row['Start'], row['End'] + 1)
 
@@ -171,14 +171,10 @@ def txt_to_graph(path):
         parent_frame = row['Start'] - 1
         source = '{}_{}'.format(row['Parent_ID'], parent_frame)
 
-        # If not in the previous frame, decrement the frame number again.
-        while source not in all_ids:
-            parent_frame = parent_frame - 1
-            if parent_frame < 0:
-                raise ValueError('Parent ID {} does not exist in any '
-                                 'frame'.format(row['Parent_ID']))
-
-            source = '{}_{}'.format(row['Parent_ID'], parent_frame)
+        if source not in all_ids:  # parents should be in the previous frame.
+            # parent_frame = df[df['Cell_ID'] == row['Parent_id']]['End']
+            # source = '{}_{}'.format(row['Parent_ID'], parent_frame)
+            continue
 
         target = '{}_{}'.format(row['Cell_ID'], row['Start'])
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -74,6 +74,9 @@ def contig_tracks(label, batch_info, batch_tracked):
                 'parent': None
             }
 
+            for d in batch_info[new_label]['daughters']:
+                batch_info[d]['parent'] = new_label
+
             for f in frames[i + 1:]:
                 batch_tracked[f][batch_tracked[f] == label] = new_label
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -144,12 +144,16 @@ def txt_to_graph(path):
     edges = pd.DataFrame()
 
     all_ids = set()
+    single_nodes = set()
 
     # Add each continuous cell lineage as a set of edges to df
     for _, row in df.iterrows():
         tpoints = np.arange(row['Start'], row['End'] + 1)
 
         cellids = ['{}_{}'.format(row['Cell_ID'], t) for t in tpoints]
+
+        if len(cellids) == 1:
+            single_nodes.add(cellids[0])
 
         all_ids.update(cellids)
 
@@ -185,6 +189,10 @@ def txt_to_graph(path):
     G = nx.from_pandas_edgelist(edges, source='source', target='target',
                                 create_using=nx.DiGraph)
     nx.set_node_attributes(G, attributes)
+
+    # Add all isolates to graph
+    for cell_id in single_nodes:
+        G.add_node(cell_id)
     return G
 
 

--- a/deepcell_tracking/isbi_utils_test.py
+++ b/deepcell_tracking/isbi_utils_test.py
@@ -124,16 +124,38 @@ class TestIsbiUtils(object):
                         assert not G.in_degree(daughter_id)
 
     def test_classify_divisions(self):
-        # G = nx.DiGraph()
-        # G.add_edge('1_0', '1_1')
-        # G.add_edge('1_1', '1_2')
-        # G.add_edge('1_2', '1_3')
-        #
-        # G.add_edge('2_0', '2_1')
-        # G.add_edge('2_1', '2_2')
-        #
-        # G.add_edge('2_1', '2_2')
-        pass
+        G = nx.DiGraph()
+        G.add_edge('1_0', '1_1')
+        G.add_edge('1_1', '1_2')
+        G.add_edge('1_2', '1_3')
+
+        G.add_edge('2_0', '2_1')
+        G.add_edge('2_1', '2_2')
+
+        # node 2 divides into 3 and 4 in frame 3
+        G.add_edge('2_2', '3_3')
+        G.add_edge('2_2', '4_3')
+        G.nodes['2_2']['division'] = True
+
+        G.add_edge('4_3', '4_4')  # another division in frame 4
+        G.nodes['4_3']['division'] = True
+
+        H = G.copy()
+
+        H.nodes['1_3']['division'] = True  # False Positive
+        H.nodes['4_3']['division'] = False  # False Negative
+
+        # force an incorrect division
+        G.add_edge('3_3', '5_4')  # another division in frame 4
+        G.nodes['3_3']['division'] = True
+        H.nodes['3_3']['division'] = True
+
+        stats = isbi_utils.classify_divisions(G, H)
+
+        assert stats['Correct division'] == 1  # the only correct one
+        assert stats['False positive division'] == 1  # node 1_3
+        assert stats['False negative division'] == 1  # node 4_3
+        assert stats['Incorrect division'] == 1  # node 3_3
 
     def test_contig_tracks(self):
         # test already contiguous

--- a/deepcell_tracking/isbi_utils_test.py
+++ b/deepcell_tracking/isbi_utils_test.py
@@ -1,0 +1,177 @@
+# Copyright 2016-2019 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/deepcell-tracking/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for utility functions for the ISBI data format."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import copy
+import tempfile
+
+import networkx as nx
+import numpy as np
+
+from deepcell_tracking import isbi_utils
+
+
+class TestIsbiUtils(object):
+
+    def test_trk_to_isbi(self):
+        # start with dummy lineage
+        # convert to ISBI file
+        # read file and validate
+
+        track = {}
+        # first cell, skips frame 3 but divides in frame 4
+        track[1] = {
+            'frames': [0, 1, 2, 4],  # skipped a frame
+            'daughters': [2, 3],
+            'frame_div': 4,
+            'parent': None,
+            'label': 1,
+        }
+        track[2] = {
+            'frames': [5],
+            'daughters': [],
+            'frame_div': None,
+            'parent': 1,
+            'label': 2,
+        }
+        track[3] = {
+            'frames': [5],
+            'daughters': [4],  # parent not in previous frame
+            'frame_div': 5,
+            'parent': 1,
+            'label': 3,
+        }
+        track[4] = {
+            'frames': [7],
+            'daughters': [],
+            'frame_div': None,
+            'parent': 3,
+            'label': 4,
+        }
+        with tempfile.NamedTemporaryFile() as temp:
+            isbi_utils.trk_to_isbi(track, temp.name)
+            data = set(l.decode() for l in temp.readlines())
+            expected = {
+                '1 0 4 0\n',
+                '2 5 5 1\n',
+                '3 5 5 1\n',
+                '4 7 7 0\n',  # no parent, as it is not consecutive frame
+            }
+            print(data)
+            assert data == expected
+
+    def test_txt_to_graph(self):
+        # cell_id, start, end, parent_id
+        rows = [
+            (1, 0, 3, 0),  # cell 1 is in all 3 frames
+            (2, 0, 2, 0),  # cell 2 is not in the last frame
+            (3, 3, 3, 2),  # cell 3 is a daughter of 2
+            (4, 3, 3, 2),  # cell 4 is a daughter of 2
+            (5, 3, 3, 4),  # cell 5 is a daughter of 4, ignored bad frame value
+        ]
+        with tempfile.NamedTemporaryFile() as text_file:
+            # write the file
+            for row in rows:
+                line = '{} {} {} {}\n'.format(row[0], row[1], row[2], row[3])
+                text_file.write(line.encode())
+
+            text_file.flush()  # save the file
+
+            # read the file
+            G = isbi_utils.txt_to_graph(text_file.name)
+            print(list(G.nodes()))
+            for row in rows:
+                node_ids = ['{}_{}'.format(row[0], t)
+                            for t in range(row[1], row[2] + 1)]
+
+                for node_id in node_ids:
+                    assert node_id in G
+
+                if row[3]:  # should have a division
+                    daughter_id = '{}_{}'.format(row[0], row[1])
+                    parent_id = '{}_{}'.format(row[3], row[1] - 1)
+                    if G.has_node(parent_id):
+                        assert G.nodes[parent_id]['division'] is True
+                        assert G.has_edge(parent_id, daughter_id)
+                    else:
+                        assert not G.in_degree(daughter_id)
+
+    def test_classify_divisions(self):
+        # G = nx.DiGraph()
+        # G.add_edge('1_0', '1_1')
+        # G.add_edge('1_1', '1_2')
+        # G.add_edge('1_2', '1_3')
+        #
+        # G.add_edge('2_0', '2_1')
+        # G.add_edge('2_1', '2_2')
+        #
+        # G.add_edge('2_1', '2_2')
+        pass
+
+    def test_contig_tracks(self):
+        # test already contiguous
+        frames = 5
+        track = {
+            1: {
+                'label': 1,
+                'frames': [0, 1, 2],
+                'daughters': [2, 3],
+                'parent': None,
+            },
+            2: {
+                'label': 2,
+                'frames': [3, 4],
+                'daughters': [],
+                'parent': 1
+            },
+            3: {
+                'label': 3,
+                'frames': [3, 4],
+                'daughters': [],
+                'parent': 1
+            }
+        }
+        original_track = copy.copy(track)
+        original_daughters = original_track[1]['daughters']
+        y = np.random.randint(0, 4, size=(frames, 40, 40, 1))
+        new_track, _ = isbi_utils.contig_tracks(1, track, y)
+        assert original_track == new_track
+
+        # test non-contiguous
+        track = copy.copy(original_track)
+        track[1]['frames'].append(4)
+        new_track, _ = isbi_utils.contig_tracks(1, track, y)
+
+        assert len(new_track) == len(original_track) + 1
+        assert new_track[1]['frames'] == original_track[1]['frames']
+        daughters = new_track[max(new_track)]['daughters']
+        assert daughters == original_daughters
+        for d in daughters:
+            assert new_track[d]['parent'] == max(new_track)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -514,9 +514,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         else:
             model_input = [ins for f in self.features for ins in inputs[f]]
             predictions = self.model.predict(model_input)
-            # TODO: using tuple (as warning indicates) changes results.
-            assignment_matrix[list(zip(*input_pairs))] = 1 - predictions[:, 1]
-            assignment_matrix[list(zip(*invalid_pairs))] = 1
+            assignment_matrix[tuple(zip(*input_pairs))] = 1 - predictions[:, 1]
+            assignment_matrix[tuple(zip(*invalid_pairs))] = 1
 
         # Assemble full cost matrix
         cost_matrix = self._build_cost_matrix(assignment_matrix)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -163,7 +163,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         """
         cells = np.unique(self._get_frame(self.y, frame))
         cells = np.delete(cells, np.where(cells == 0))  # remove the background
-        return sorted(list(cells))
+        return list(cells)
 
     def get_feature_shape(self, feature_name):
         """Return the shape of the requested feature.

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -41,6 +41,42 @@ import numpy as np
 from skimage import transform
 
 
+def clean_up_annotations(y, uid=None, data_format='channels_last'):
+    """Relabels every frame in the label matrix.
+
+    Args:
+        y (np.array): annotations to relabel sequentially.
+        uid (int, optional): starting ID to begin labeling cells.
+        data_format (str): determines the order of the channel axis,
+            one of 'channels_first' and 'channels_last'.
+
+    Returns:
+        np.array: Cleaned up annotations.
+    """
+    time_axis = 1 if data_format == 'channels_first' else 0
+    num_frames = y.shape[time_axis]
+
+    all_uniques = []
+    for f in range(num_frames):
+        cells = np.unique(y[:, f] if data_format == 'channels_first' else y[f])
+        cells = np.delete(cells, np.where(cells == 0))
+        all_uniques.append(cells)
+
+    # The annotations need to be unique across all frames
+    uid = sum(len(x) for x in all_uniques) + 1 if uid is None else uid
+    for frame, unique_cells in zip(range(num_frames), all_uniques):
+        y_frame = y[:, frame] if data_format == 'channels_first' else y[frame]
+        y_frame_new = np.zeros(y_frame.shape)
+        for cell_label in unique_cells:
+            y_frame_new[y_frame == cell_label] = uid
+            uid += 1
+        if data_format == 'channels_first':
+            y[:, frame] = y_frame_new
+        else:
+            y[frame] = y_frame_new
+    return y.astype('int32')
+
+
 def resize(data, shape, data_format='channels_last'):
     """Resize the data to the given shape.
 

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -106,7 +106,7 @@ def resize(data, shape, data_format='channels_last'):
                                    mode='constant',
                                    preserve_range=True)
     else:  # single channel image, resize with cv2
-        resized = cv2.resize(np.squeeze(data), shape)  # pytest: disable=E1101
+        resized = cv2.resize(np.squeeze(data), shape)  # pylint: disable=E1101
         resized = np.expand_dims(resized, axis=channel_axis)
 
     return resized

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -29,6 +29,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import skimage as sk
 
 from deepcell_tracking import utils
 
@@ -41,6 +42,30 @@ def _get_image(img_h=300, img_w=300):
 
 
 class TestTrackingUtils(object):
+
+    def test_clean_up_annotations(self):
+        img = sk.measure.label(sk.data.binary_blobs(length=256, n_dim=2)) * 3
+        img = np.expand_dims(img, axis=-1)
+        uid = 100
+
+        cleaned = utils.clean_up_annotations(
+            img, uid=uid, data_format='channels_last')
+        unique = np.unique(cleaned)
+        assert len(np.unique(img)) == len(unique)
+        expected = np.arange(len(unique)) + uid - 1
+        expected[0] = 0  # background shouldn't get added
+        np.testing.assert_equal(expected, unique)
+
+        img = sk.measure.label(sk.data.binary_blobs(length=256, n_dim=2)) * 3
+        img = np.expand_dims(img, axis=0)
+
+        cleaned = utils.clean_up_annotations(
+            img, uid=uid, data_format='channels_first')
+        unique = np.unique(cleaned)
+        assert len(np.unique(img)) == len(unique)
+        expected = np.arange(len(unique)) + uid - 1
+        expected[0] = 0  # background shouldn't get added
+        np.testing.assert_equal(expected, unique)
 
     def test_resize(self):
         channel_sizes = (3, 1)  # skimage used for multi-channel, cv2 otherwise


### PR DESCRIPTION
* Moved `clean_up_annotations` to `utils.py` to more easily import and use it elsewhere.

* Convert Graphs to DiGraphs to clearly differentiate between parents and daughters to define a correct division node.

* Added `trk_to_isbi` to easily create the ISBI txt files.

* Fixed bug in `txt_to_graph` that allowed parents to exist in a frame that is not the previous frame.

* Fixed bug in `contig_tracks` that did not properly match parents and daughters between "new" contiguous tracks.

* Improve test coverage for `isbi_utils`

* Updated `CellTracker._get_cost_matrix` to use `tuple` instead of `list (Fixes #16)