### PR TITLE
Create inner _track_frame function and improve test coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,7 @@ exclude_lines =
     raise NotImplementedError
 
 ignore_errors = True
-fail_under = 50
+fail_under = 75
 show_missing = True
 
 omit =

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,7 @@ exclude_lines =
     raise NotImplementedError
 
 ignore_errors = True
-fail_under = 75
+fail_under = 50
 show_missing = True
 
 omit =

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,7 @@ exclude_lines =
     raise NotImplementedError
 
 ignore_errors = True
-fail_under = 50
+fail_under = 80
 show_missing = True
 
 omit =

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ pip install -r requirements.txt
 ## How to Use
 
 ```python
-from deepcell_tracking import cell_tracker
+from deepcell_tracking import CellTracker
 
 # X and y are the time-sequence data and their corresponding segmentations (labels), respectively.
 # model is a deepcell-tf tracking model.
-tracker = cell_tracker(X, y, model)
+tracker = CellTracker(X, y, model)
 
-tracker._track_cells()  # runs in place, builds tracks
+tracker.track_cells()  # runs in place, builds tracks
 
 # Save all tracked data and lineage files to a .trk file
 tracker.dump('./results.trk')

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -872,38 +872,18 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         # Save information to a track file file if requested
         if filename is not None:
-            # Prep filepath
-            filename = pathlib.Path(filename)
-            if filename.suffix != '.trk':
-                filename = filename.with_suffix('.trk')
-
-            filename = str(filename)
-
-            # Save
-            with tarfile.open(filename, 'w') as trks:
-                with tempfile.NamedTemporaryFile('w') as lineage_file:
-                    json.dump(track_review_dict['tracks'], lineage_file, indent=1)
-                    lineage_file.flush()
-                    trks.add(lineage_file.name, 'lineage.json')
-
-                with tempfile.NamedTemporaryFile() as raw_file:
-                    np.save(raw_file, track_review_dict['X'])
-                    raw_file.flush()
-                    trks.add(raw_file.name, 'raw.npy')
-
-                with tempfile.NamedTemporaryFile() as tracked_file:
-                    np.save(tracked_file, track_review_dict['y_tracked'])
-                    tracked_file.flush()
-                    trks.add(tracked_file.name, 'tracked.npy')
+            self.dump(filename, track_review_dict)
 
         return track_review_dict
 
-    def dump(self, filename):
+    def dump(self, filename, track_review_dict=None):
         """Writes the state of the cell tracker to a .trk ('track') file.
         Includes raw & tracked images, and a lineage.json for parent/daughter
         information.
         """
-        track_review_dict = self._track_review_dict()
+        if not track_review_dict:
+            track_review_dict = self._track_review_dict()
+
         filename = pathlib.Path(filename)
 
         if filename.suffix != '.trk':

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -758,6 +758,20 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             '~future area': np.expand_dims(future_area, axis=0)
         }
 
+    def _track_frame(self, frame):
+        """Inner function for tracking each frame"""
+        t = timeit.default_timer()
+        self.logger.info('Tracking frame %s', frame)
+
+        cost_matrix, predictions = self._get_cost_matrix(frame)
+
+        row_ind, col_ind = linear_sum_assignment(cost_matrix)
+        assignments = np.stack([row_ind, col_ind], axis=1)
+
+        self._update_tracks(assignments, frame, predictions)
+        self.logger.info('Tracked frame %s in %s s.',
+                         frame, timeit.default_timer() - t)
+
     def track_cells(self):
         """Tracks all of the cells in every frame.
         """
@@ -765,17 +779,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         self._initialize_tracks()
 
         for frame in range(1, self.x.shape[self.time_axis]):
-            t = timeit.default_timer()
-            self.logger.info('Tracking frame %s', frame)
+            self._track_frame(frame)
 
-            cost_matrix, predictions = self._get_cost_matrix(frame)
-
-            row_ind, col_ind = linear_sum_assignment(cost_matrix)
-            assignments = np.stack([row_ind, col_ind], axis=1)
-
-            self._update_tracks(assignments, frame, predictions)
-            self.logger.info('Tracked frame %s in %s s.',
-                             frame, timeit.default_timer() - t)
         self.logger.info('Tracked all %s frames in %s s.',
                          self.x.shape[self.time_axis],
                          timeit.default_timer() - start)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -983,8 +983,6 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         for candidate_node in FPs_candidates:
             node = candidate_node[0]
             node_info = candidate_node[1]
-            fp_label = int(node.split('_')[0])
-            fp_frame = int(node.split('_')[1])
 
             neighbors = []  # structure will be [(neighbor1, frame), (neighbor2,frame)]
             for neighbor in node_info['neighbors']:

--- a/deepcell_tracking/tracking_test.py
+++ b/deepcell_tracking/tracking_test.py
@@ -54,7 +54,7 @@ def _get_dummy_tracking_data(length=128, frames=3,
     while len(x) < frames:
         _x = sk.data.binary_blobs(length=length, n_dim=2)
         _y = sk.measure.label(_x)
-        if len(np.unique(_y)) > 2:
+        if len(np.unique(_y)) > 3:
             x.append(_x)
             y.append(_y)
 

--- a/deepcell_tracking/tracking_test.py
+++ b/deepcell_tracking/tracking_test.py
@@ -29,6 +29,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+import tempfile
+
 import numpy as np
 import pandas as pd
 import skimage as sk
@@ -130,14 +133,25 @@ class TestTracking(object):  # pylint: disable=useless-object-inheritance
             # test tracker.dataframe
             df = tracker.dataframe(cell_type='test-value')
             assert isinstance(df, pd.DataFrame)
-            assert 'cell_type' in df.columns
+            assert 'cell_type' in df.columns  # pylint: disable=E1135
 
             # test incorrect values in tracker.dataframe
             with pytest.raises(ValueError):
                 tracker.dataframe(bad_value=-1)
 
             # test tracker.postprocess
-            tracker.postprocess()
+            with tempfile.TemporaryDirectory() as tempdir:
+                path = os.path.join(tempdir, 'postprocess.xyz')
+                tracker.postprocess(filename=path)
+                saved_path = os.path.join(tempdir, 'postprocess.trk')
+                assert os.path.isfile(saved_path)
+
+            # test tracker.dump
+            with tempfile.TemporaryDirectory() as tempdir:
+                path = os.path.join(tempdir, 'test.xyz')
+                tracker.dump(path)
+                saved_path = os.path.join(tempdir, 'test.trk')
+                assert os.path.isfile(saved_path)
 
     def test_fetch_tracked_features(self):
         length = 128

--- a/deepcell_tracking/tracking_test.py
+++ b/deepcell_tracking/tracking_test.py
@@ -111,7 +111,7 @@ class TestTracking(object):  # pylint: disable=useless-object-inheritance
         with pytest.raises(ValueError):
             tracking.CellTracker(x, y, model=model, data_format='invalid')
 
-    def test__track_cells(self):
+    def test_track_cells(self):
         length = 128
         frames = 5
         track_length = 2

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -28,8 +28,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import errno
+import os
+import shutil
+import tempfile
+
 import numpy as np
 import skimage as sk
+
+import pytest
 
 from deepcell_tracking import utils
 
@@ -102,3 +109,25 @@ class TestTrackingUtils(object):
         pairs = utils.count_pairs(
             y, same_probability=prob, data_format='channels_first')
         assert pairs == expected
+
+    def test_save_trks(self):
+        X = _get_image(30, 30)
+        y = np.random.randint(low=0, high=10, size=X.shape)
+        lineage = [dict()]
+
+        try:
+            tempdir = tempfile.mkdtemp()  # create dir
+            with pytest.raises(ValueError):
+                badfilename = os.path.join(tempdir, 'x.trk')
+                utils.save_trks(badfilename, lineage, X, y)
+
+            filename = os.path.join(tempdir, 'x.trks')
+            utils.save_trks(filename, lineage, X, y)
+            assert os.path.isfile(filename)
+
+        finally:
+            try:
+                shutil.rmtree(tempdir)  # delete directory
+            except OSError as exc:
+                if exc.errno != errno.ENOENT:  # no such file or directory
+                    raise  # re-raise exception


### PR DESCRIPTION
Add tests for `dump()` and DRY out `postprocess` by calling `dump`.

Add inner function `_track_frame` called on every frame inside the `track_cells` loop.  This way it is easier to modify the code and call `model.progress` in each loop.

Update the coverage requirement to 75%.

Fixes #21 