### PR TITLE
Use headless builds of OpenCV

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
+pathlib
 pandas>=0.23.4
 networkx>=2.1
 numpy>=1.16.4,<2
 scipy>=1.1.0,<2
 scikit-image>=0.14.0,<0.17
 opencv-python-headless<=3.4.9.31
-pathlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy>=1.16.4,<2
-pandas>=0.23.3,<1
+pandas>=0.23.4
 networkx>=2.1
+numpy>=1.16.4,<2
 scipy>=1.1.0,<2
 scikit-image>=0.14.0,<0.17
-opencv-python<=3.4.9.31
+opencv-python-headless<=3.4.9.31
 pathlib

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='Deepcell_Tracking',
       download_url='https://github.com/vanvalenlab/'
                    'deepcell-tracking/tarball/{}'.format(VERSION),
       license='LICENSE',
-      install_requires=['opencv-python<=3.4.9.31',
+      install_requires=['opencv-python-headless<=3.4.9.31',
                         'networkx>=2.1',
                         'numpy',
                         'pandas',


### PR DESCRIPTION
From the `opencv-python-headless` README:

> Packages for server (headless) environments (such as Docker, cloud environments etc.), no GUI library dependencies
> 
> These packages are smaller than the two other packages above because they do not contain any GUI functionality (not compiled with Qt / other GUI components). This means that the packages avoid a heavy dependency chain to X11 libraries and you will have for example smaller Docker images as a result. **You should always use these packages if you do not use cv2.imshow et al. or you are using some other package (such as PyQt) than OpenCV to create your GUI**.

Since we only use `cv2` for resizing images, we should use the headless build.