### PR TITLE
Use environment markers in setup.py to conditionally change opencv versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
         # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
@@ -36,8 +36,8 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-test.txt
+        pip install .[tests]
+        pip install coveralls
 
     - name: Run PyTest and Coveralls
       env:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git clone https://github.com/vanvalenlab/deepcell-tracking.git
 cd deepcell-tracking
 
 # install the dependencies
-pip install -r requirements.txt
+pip install .
 ```
 
 ## How to Use

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,0 @@
-pytest<6
-pytest-cov
-pytest-pep8
-coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-pathlib
-pandas>=0.23.4
-networkx>=2.1
-numpy>=1.16.4,<2
-scipy>=1.1.0,<2
-scikit-image>=0.14.0,<0.17
-opencv-python-headless<=3.4.9.31

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,14 @@ from codecs import open
 from setuptools import setup
 from setuptools import find_packages
 
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
+    readme = f.read()
+
+
 VERSION = '0.3.1'
 NAME = 'DeepCell_Tracking'
 DESCRIPTION = 'Tracking cells and lineage with deep learning.'
@@ -39,8 +47,6 @@ URL = 'https://github.com/vanvalenlab/deepcell-tracking'
 DOWNLOAD_URL = ('https://github.com/vanvalenlab/'
                 'deepcell-tracking/tarball/{}'.format(VERSION))
 
-with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
-    readme = f.read()
 
 setup(name=NAME,
       version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -71,4 +71,4 @@ setup(name=NAME,
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8']))
+          'Programming Language :: Python :: 3.8'])

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import os
+
 from codecs import open
 from setuptools import setup
 from setuptools import find_packages

--- a/setup.py
+++ b/setup.py
@@ -23,29 +23,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from codecs import open
 from setuptools import setup
 from setuptools import find_packages
 
-VERSION = '0.3.0'
+VERSION = '0.3.1'
+NAME = 'DeepCell_Tracking'
+DESCRIPTION = 'Tracking cells and lineage with deep learning.'
+LICENSE = 'LICENSE'
+AUTHOR = 'Van Valen Lab'
+AUTHOR_EMAIL = 'vanvalenlab@gmail.com'
+URL = 'https://github.com/vanvalenlab/deepcell-tracking'
+DOWNLOAD_URL = ('https://github.com/vanvalenlab/'
+                'deepcell-tracking/tarball/{}'.format(VERSION))
 
-setup(name='Deepcell_Tracking',
+with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
+    readme = f.read()
+
+setup(name=NAME,
       version=VERSION,
-      description='Tracking cells and lineage with deep learning.',
-      author='Van Valen Lab',
-      author_email='vanvalenlab@gmail.com',
-      url='https://github.com/vanvalenlab/deepcell-tracking',
-      download_url='https://github.com/vanvalenlab/'
-                   'deepcell-tracking/tarball/{}'.format(VERSION),
-      license='LICENSE',
-      install_requires=['opencv-python-headless<=3.4.9.31',
+      description=DESCRIPTION,
+      author=AUTHOR,
+      author_email=AUTHOR_EMAIL,
+      url=URL,
+      download_url=DOWNLOAD_URL,
+      license=LICENSE,
+      install_requires=['opencv-python-headless<=4.2.0.32; python_version < "3"',
+                        'opencv-python-headless>=4.2.0.32; python_version >= "3"',
                         'networkx>=2.1',
                         'numpy',
                         'pandas',
                         'pathlib',
                         'scipy',
-                        'scikit-image'],
+                        'scikit-image<0.17'],
       extras_require={
-          'tests': ['pytest',
+          'tests': ['pytest<6',
                     'pytest-pep8',
                     'pytest-cov']},
-      packages=find_packages())
+      long_description=readme,
+      long_description_content_type='text/markdown',
+      packages=find_packages(),
+      classifiers=[
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8']))


### PR DESCRIPTION
[Environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers) allow `pip` to dynamically install the appropriate version of a package for different versions of Python. While this is not an issue for most dependencies (`scipy`, `numpy`, etc.), `opencv-python-headless` will attempt to install the latest version of the package even for unsupported Python versions.

This PR removes `requirements.txt` and `requirements-test.txt` in favor of using `setup.py`, where we can set the version of `opencv-python-headless` for each Python version.