### PR TITLE
Run tests against each OS version.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,11 +8,12 @@ on: [push, pull_request]
 jobs:
   tests:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Use GitHub Actions build matrix to run tests for Ubuntu, Windows, and MacOS.