### PR TITLE
Use tmpdir test fixture instead of NamedTemporaryFile for Windows compatibility.

### DIFF
--- a/deepcell_tracking/isbi_utils_test.py
+++ b/deepcell_tracking/isbi_utils_test.py
@@ -31,7 +31,6 @@ from __future__ import print_function
 
 import copy
 import os
-import tempfile
 
 import networkx as nx
 import numpy as np

--- a/deepcell_tracking/isbi_utils_test.py
+++ b/deepcell_tracking/isbi_utils_test.py
@@ -82,10 +82,10 @@ class TestIsbiUtils(object):
             data = set(l.decode() for l in f.readlines())
 
         expected = {
-            '1 0 4 0\n',
-            '2 5 5 1\n',
-            '3 5 5 1\n',
-            '4 7 7 0\n',  # no parent, as it is not consecutive frame
+            '1 0 4 0{}'.format(os.linesep),
+            '2 5 5 1{}'.format(os.linesep),
+            '3 5 5 1{}'.format(os.linesep),
+            '4 7 7 0{}'.format(os.linesep),  # no parent; not consecutive frame
         }
         assert data == expected
 
@@ -102,7 +102,8 @@ class TestIsbiUtils(object):
         with open(text_file, 'wb') as f:
             # write the file
             for row in rows:
-                line = '{} {} {} {}\n'.format(row[0], row[1], row[2], row[3])
+                line = '{} {} {} {}{}'.format(
+                    row[0], row[1], row[2], row[3], os.linesep)
                 f.write(line.encode())
 
             f.flush()  # save the file

--- a/deepcell_tracking/isbi_utils_test.py
+++ b/deepcell_tracking/isbi_utils_test.py
@@ -30,6 +30,7 @@ from __future__ import division
 from __future__ import print_function
 
 import copy
+import os
 import tempfile
 
 import networkx as nx
@@ -40,7 +41,7 @@ from deepcell_tracking import isbi_utils
 
 class TestIsbiUtils(object):
 
-    def test_trk_to_isbi(self):
+    def test_trk_to_isbi(self, tmpdir):
         # start with dummy lineage
         # convert to ISBI file
         # read file and validate
@@ -75,19 +76,21 @@ class TestIsbiUtils(object):
             'parent': 3,
             'label': 4,
         }
-        with tempfile.NamedTemporaryFile() as temp:
-            isbi_utils.trk_to_isbi(track, temp.name)
-            data = set(l.decode() for l in temp.readlines())
-            expected = {
-                '1 0 4 0\n',
-                '2 5 5 1\n',
-                '3 5 5 1\n',
-                '4 7 7 0\n',  # no parent, as it is not consecutive frame
-            }
-            print(data)
-            assert data == expected
+        isbifile = os.path.join(str(tmpdir), 'test_trk_to_isbi')
+        isbi_utils.trk_to_isbi(track, isbifile)
 
-    def test_txt_to_graph(self):
+        with open(isbifile, 'rb') as f:
+            data = set(l.decode() for l in f.readlines())
+
+        expected = {
+            '1 0 4 0\n',
+            '2 5 5 1\n',
+            '3 5 5 1\n',
+            '4 7 7 0\n',  # no parent, as it is not consecutive frame
+        }
+        assert data == expected
+
+    def test_txt_to_graph(self, tmpdir):
         # cell_id, start, end, parent_id
         rows = [
             (1, 0, 3, 0),  # cell 1 is in all 3 frames
@@ -96,32 +99,32 @@ class TestIsbiUtils(object):
             (4, 3, 3, 2),  # cell 4 is a daughter of 2
             (5, 3, 3, 4),  # cell 5 is a daughter of 4, ignored bad frame value
         ]
-        with tempfile.NamedTemporaryFile() as text_file:
+        text_file = os.path.join(str(tmpdir), 'test_txt_to_graph.txt')
+        with open(text_file, 'wb') as f:
             # write the file
             for row in rows:
                 line = '{} {} {} {}\n'.format(row[0], row[1], row[2], row[3])
-                text_file.write(line.encode())
+                f.write(line.encode())
 
-            text_file.flush()  # save the file
+            f.flush()  # save the file
 
-            # read the file
-            G = isbi_utils.txt_to_graph(text_file.name)
-            print(list(G.nodes()))
-            for row in rows:
-                node_ids = ['{}_{}'.format(row[0], t)
-                            for t in range(row[1], row[2] + 1)]
+        # read the file
+        G = isbi_utils.txt_to_graph(text_file)
+        for row in rows:
+            node_ids = ['{}_{}'.format(row[0], t)
+                        for t in range(row[1], row[2] + 1)]
 
-                for node_id in node_ids:
-                    assert node_id in G
+            for node_id in node_ids:
+                assert node_id in G
 
-                if row[3]:  # should have a division
-                    daughter_id = '{}_{}'.format(row[0], row[1])
-                    parent_id = '{}_{}'.format(row[3], row[1] - 1)
-                    if G.has_node(parent_id):
-                        assert G.nodes[parent_id]['division'] is True
-                        assert G.has_edge(parent_id, daughter_id)
-                    else:
-                        assert not G.in_degree(daughter_id)
+            if row[3]:  # should have a division
+                daughter_id = '{}_{}'.format(row[0], row[1])
+                parent_id = '{}_{}'.format(row[3], row[1] - 1)
+                if G.has_node(parent_id):
+                    assert G.nodes[parent_id]['division'] is True
+                    assert G.has_edge(parent_id, daughter_id)
+                else:
+                    assert not G.in_degree(daughter_id)
 
     def test_classify_divisions(self):
         G = nx.DiGraph()

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -898,7 +898,8 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             with tempfile.NamedTemporaryFile('w') as lineage_file:
                 json.dump(track_review_dict['tracks'], lineage_file, indent=1)
                 lineage_file.flush()
-                trks.add(lineage_file.name, 'lineage.json')
+                name = lineage_file.name
+                trks.add(name, 'lineage.json')
 
             with tempfile.NamedTemporaryFile() as raw_file:
                 np.save(raw_file, track_review_dict['X'])

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -895,7 +895,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         filename = str(filename)
 
         with tarfile.open(filename, 'w') as trks:
-            with tempfile.NamedTemporaryFile() as lineage_file:
+            with tempfile.NamedTemporaryFile('w') as lineage_file:
                 json.dump(track_review_dict['tracks'], lineage_file, indent=1)
                 lineage_file.flush()
                 trks.add(lineage_file.name, 'lineage.json')

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -895,7 +895,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         filename = str(filename)
 
         with tarfile.open(filename, 'w') as trks:
-            with tempfile.NamedTemporaryFile('w') as lineage_file:
+            with tempfile.NamedTemporaryFile() as lineage_file:
                 json.dump(track_review_dict['tracks'], lineage_file, indent=1)
                 lineage_file.flush()
                 trks.add(lineage_file.name, 'lineage.json')

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -896,7 +896,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         with tarfile.open(filename, 'w') as trks:
             with tempfile.NamedTemporaryFile('w') as lineage_file:
-                json.dump(track_review_dict['tracks'], lineage_file, indent=1)
+                json.dump(track_review_dict['tracks'], lineage_file, indent=4)
                 lineage_file.flush()
                 name = lineage_file.name
                 trks.add(name, 'lineage.json')

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -256,7 +256,7 @@ def save_trks(filename, lineages, raw, tracked):
             raw_file.flush()
             raw_file.close()
             trks.add(raw_file.name, 'raw.npy')
-            os.remove(lineages_file.name)
+            os.remove(raw_file.name)
 
         with tempfile.NamedTemporaryFile(delete=False) as tracked_file:
             np.save(tracked_file, tracked)

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -244,20 +244,26 @@ def save_trks(filename, lineages, raw, tracked):
         raise ValueError('filename must end with `.trks`. Found %s' % filename)
 
     with tarfile.open(filename, 'w') as trks:
-        with tempfile.NamedTemporaryFile('w') as lineages_file:
-            json.dump(lineages, lineages_file, indent=1)
+        with tempfile.NamedTemporaryFile('w', delete=False) as lineages_file:
+            json.dump(lineages, lineages_file, indent=4)
             lineages_file.flush()
+            lineages_file.close()
             trks.add(lineages_file.name, 'lineages.json')
+            os.remove(lineages_file.name)
 
-        with tempfile.NamedTemporaryFile() as raw_file:
+        with tempfile.NamedTemporaryFile(delete=False) as raw_file:
             np.save(raw_file, raw)
             raw_file.flush()
+            raw_file.close()
             trks.add(raw_file.name, 'raw.npy')
+            os.remove(lineages_file.name)
 
-        with tempfile.NamedTemporaryFile() as tracked_file:
+        with tempfile.NamedTemporaryFile(delete=False) as tracked_file:
             np.save(tracked_file, tracked)
             tracked_file.flush()
+            tracked_file.close()
             trks.add(tracked_file.name, 'tracked.npy')
+            os.remove(tracked_file.name)
 
 
 def trks_stats(filename):

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -125,6 +125,12 @@ class TestTrackingUtils(object):
             utils.save_trks(filename, lineage, X, y)
             assert os.path.isfile(filename)
 
+            # test saved tracks can be loaded
+            loaded = utils.load_trks(filename)
+            assert loaded['lineages'] == lineage
+            np.testing.assert_array_equal(X, loaded['X'])
+            np.testing.assert_array_equal(y, loaded['y'])
+
         finally:
             try:
                 shutil.rmtree(tempdir)  # delete directory


### PR DESCRIPTION
On Windows, the `tempfile.NamedTemporaryFile` cannot be opened while it is currently open (which is not an issue on macOS/Ubuntu).

In our tests, `save_trks`, and `tracker.dump`, we create a `NamedTemporaryFile` and try to add it to the tarfile. Internally in `tarfile.add`, the `NamedTemporaryFile` is opened again, causing an `IOError` in Windows.

To avoid this, the tests have been replaced with the testing fixture `tmpdir`, and both `save_trks` and `.dump` have been updated to use `NamedTemporaryFile(delete=False)` and manually closing and deleting the file.

While this is not ideal, I cannot find another workaround to prevent this issue on Windows.

---

Additionally, some other tests have been updated to use `os.linesep` instead of the `\n` character.