### PR TITLE
transform dtype early

### DIFF
--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -53,6 +53,7 @@ def clean_up_annotations(y, uid=None, data_format='channels_last'):
     Returns:
         np.array: Cleaned up annotations.
     """
+    y = y.astype('int32')
     time_axis = 1 if data_format == 'channels_first' else 0
     num_frames = y.shape[time_axis]
 
@@ -74,7 +75,7 @@ def clean_up_annotations(y, uid=None, data_format='channels_last'):
             y[:, frame] = y_frame_new
         else:
             y[frame] = y_frame_new
-    return y.astype('int32')
+    return y
 
 
 def resize(data, shape, data_format='channels_last'):

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -53,8 +53,9 @@ class TestTrackingUtils(object):
     def test_clean_up_annotations(self):
         img = sk.measure.label(sk.data.binary_blobs(length=256, n_dim=2)) * 3
         img = np.expand_dims(img, axis=-1)
+        img = np.expand_dims(img, axis=0)
         uid = 100
-
+        
         cleaned = utils.clean_up_annotations(
             img, uid=uid, data_format='channels_last')
         unique = np.unique(cleaned)
@@ -65,6 +66,7 @@ class TestTrackingUtils(object):
 
         img = sk.measure.label(sk.data.binary_blobs(length=256, n_dim=2)) * 3
         img = np.expand_dims(img, axis=0)
+        img = np.expand_dims(img, axis=1) # time axis
 
         cleaned = utils.clean_up_annotations(
             img, uid=uid, data_format='channels_first')

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -55,7 +55,7 @@ class TestTrackingUtils(object):
         img = np.expand_dims(img, axis=-1) 
         img = np.expand_dims(img, axis=0)  # time axis
         uid = 100
-        
+
         cleaned = utils.clean_up_annotations(
             img, uid=uid, data_format='channels_last')
         unique = np.unique(cleaned)

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -50,10 +50,10 @@ def _get_image(img_h=300, img_w=300):
 
 class TestTrackingUtils(object):
 
-    def test_clean_up_annotations(self):
+   def test_clean_up_annotations(self):
         img = sk.measure.label(sk.data.binary_blobs(length=256, n_dim=2)) * 3
-        img = np.expand_dims(img, axis=-1)
-        img = np.expand_dims(img, axis=0)
+        img = np.expand_dims(img, axis=-1) 
+        img = np.expand_dims(img, axis=0)  # time axis
         uid = 100
         
         cleaned = utils.clean_up_annotations(
@@ -66,7 +66,7 @@ class TestTrackingUtils(object):
 
         img = sk.measure.label(sk.data.binary_blobs(length=256, n_dim=2)) * 3
         img = np.expand_dims(img, axis=0)
-        img = np.expand_dims(img, axis=1) # time axis
+        img = np.expand_dims(img, axis=1)  # time axis
 
         cleaned = utils.clean_up_annotations(
             img, uid=uid, data_format='channels_first')

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -50,7 +50,7 @@ def _get_image(img_h=300, img_w=300):
 
 class TestTrackingUtils(object):
 
-   def test_clean_up_annotations(self):
+    def test_clean_up_annotations(self):
         img = sk.measure.label(sk.data.binary_blobs(length=256, n_dim=2)) * 3
         img = np.expand_dims(img, axis=-1) 
         img = np.expand_dims(img, axis=0)  # time axis

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -52,7 +52,7 @@ class TestTrackingUtils(object):
 
     def test_clean_up_annotations(self):
         img = sk.measure.label(sk.data.binary_blobs(length=256, n_dim=2)) * 3
-        img = np.expand_dims(img, axis=-1) 
+        img = np.expand_dims(img, axis=-1)
         img = np.expand_dims(img, axis=0)  # time axis
         uid = 100
 


### PR DESCRIPTION
In clean_up_annotations(), transform y to int32 at the beginning to avoid overflow when applying new uids to the original matrix.