### PR TITLE
Use each coveralls key with os and python versions.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Run PyTest and Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        COVERALLS_FLAG_NAME: python-${{ matrix.os-version }}-${{ matrix.python-version }}
+        COVERALLS_FLAG_NAME: python-${{ matrix.os }}-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
       run: |
         pytest --cov deepcell_tracking --pep8

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Run PyTest and Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}
+        COVERALLS_FLAG_NAME: python-${{ matrix.os-version }}-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
       run: |
         pytest --cov deepcell_tracking --pep8


### PR DESCRIPTION
Split out each coverage report by OS and python version, instead of collapsing into the same coverage report for all OS versions.