### PR TITLE
Split PyTest and Coveralls into separate steps.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
         pip install .[tests]
         pip install coveralls
 
-    - name: Run PyTest and Coveralls
+    - name: PyTest
       run: |
         pytest --cov deepcell_tracking --pep8
     

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
         pytest --cov deepcell_tracking --pep8
     
     - name: Coveralls
-      if: github.token != ""
+      if: ${{ github.token != "" }}
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_FLAG_NAME: python-${{ matrix.os }}-${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,12 +41,15 @@ jobs:
         pip install coveralls
 
     - name: Run PyTest and Coveralls
+      run: |
+        pytest --cov deepcell_tracking --pep8
+    
+    - name: Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_FLAG_NAME: python-${{ matrix.os }}-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
       run: |
-        pytest --cov deepcell_tracking --pep8
         coveralls
 
   coveralls:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,6 +45,7 @@ jobs:
         pytest --cov deepcell_tracking --pep8
     
     - name: Coveralls
+      if: github.token != ""
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_FLAG_NAME: python-${{ matrix.os }}-${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
         pytest --cov deepcell_tracking --pep8
     
     - name: Coveralls
-      if: ${{ github.token != "" }}
+      if: ${{ github.token != '' }}
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_FLAG_NAME: python-${{ matrix.os }}-${{ matrix.python-version }}


### PR DESCRIPTION
This is a new feature that did not work when the project first migrated to GitHub Actions.