### PR TITLE
Only run Coveralls if COVERALLS_REPO_TOKEN is set.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,6 +57,9 @@ jobs:
     name: Finish Coveralls
     needs: tests
     runs-on: ubuntu-latest
+    if: env.COVERALLS_REPO_TOKEN != null
+    env:
+      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@master

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,12 +57,12 @@ jobs:
     name: Finish Coveralls
     needs: tests
     runs-on: ubuntu-latest
-    if: env.COVERALLS_REPO_TOKEN != null
-    env:
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@master
+      if: env.COVERALLS_REPO_TOKEN != null
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
         pytest --cov deepcell_tracking --pep8
     
     - name: Coveralls
-      if: ${{ github.token != '' }}
+      if: env.COVERALLS_REPO_TOKEN != null
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_FLAG_NAME: python-${{ matrix.os }}-${{ matrix.python-version }}


### PR DESCRIPTION
Forked repositories will not have access to `COVERALLS_REPO_TOKEN`, and the tests will not run due to a filed Coveralls step. Instead, conditionally run the Coveralls step only if `COVERALLS_REPO_TOKEN` is set.