### PR TITLE
Remove scikit-image version restriction.

### DIFF
--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -686,7 +686,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         y_padded = np.pad(y_frame, pads, mode='constant', constant_values=0)
 
         roi = (y_padded == cell_label).astype('int32')
-        props = regionprops(np.squeeze(roi), coordinates='rc')
+        props = regionprops(np.squeeze(roi))
 
         center_x, center_y = props[0].centroid
         center_x, center_y = np.int(center_x), np.int(center_y)
@@ -722,7 +722,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         y_frame = self._get_frame(self.y, frame)
 
         roi = (y_frame == cell_label).astype('int32')
-        props = regionprops(np.squeeze(roi), coordinates='rc')[0]
+        props = regionprops(np.squeeze(roi))[0]
 
         centroid = props.centroid
         rprop = np.array([

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -686,7 +686,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         y_padded = np.pad(y_frame, pads, mode='constant', constant_values=0)
 
         roi = (y_padded == cell_label).astype('int32')
-        props = regionprops(np.squeeze(roi))
+        props = regionprops(np.squeeze(roi), coordinates='rc')
 
         center_x, center_y = props[0].centroid
         center_x, center_y = np.int(center_x), np.int(center_y)
@@ -722,7 +722,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         y_frame = self._get_frame(self.y, frame)
 
         roi = (y_frame == cell_label).astype('int32')
-        props = regionprops(np.squeeze(roi))[0]
+        props = regionprops(np.squeeze(roi), coordinates='rc')[0]
 
         centroid = props.centroid
         rprop = np.array([

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(name=NAME,
                         'pandas',
                         'pathlib',
                         'scipy',
-                        'scikit-image'],
+                        'scikit-image>=0.14.5'],
       extras_require={
           'tests': ['pytest<6',
                     'pytest-pep8',

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(name=NAME,
                         'pandas',
                         'pathlib',
                         'scipy',
-                        'scikit-image<0.17'],
+                        'scikit-image'],
       extras_require={
           'tests': ['pytest<6',
                     'pytest-pep8',


### PR DESCRIPTION
Change the `<17` version restriction for `scikit-image` to `>=0.14.5` as it is unnecessarily limiting for other projects using `deepcell-tracking`, and the breaking changes in .17+ are not relevant.

Additionally, remove the deprecated `coordinates="rc"` from `regionprops` calls.
