### PR TITLE
Change shape of feature arrays to use time as the first axis.

### DIFF
--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -446,7 +446,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             ], axis=0)
 
             # Add time dimension
-            future_feature_arr = np.expand_dims(future_feature_arr, axis=1)
+            future_feature_arr = np.expand_dims(future_feature_arr, axis=0)
 
             # Add batch dimension
             current_feature_arr = np.expand_dims(current_feature_arr, axis=0)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -440,7 +440,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
             # Convert from dict to arrays
             current_feature_arr = np.stack([
                 current_feature[k] for k in current_feature
-            ], axis=0)
+            ], axis=1)  # time axis already included
             future_feature_arr = np.stack([
                 future_feature[k] for k in future_feature
             ], axis=0)

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -194,23 +194,18 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         n_frames = self.X.shape[0]
         n_channels = self.X.shape[-1]
 
-        appearances = np.zeros((max_cells,
-                                n_frames,
+        appearances = np.zeros((n_frames,
+                                max_cells,
                                 self.appearance_dim,
                                 self.appearance_dim,
                                 n_channels), dtype=np.float32)
 
-        morphologies = np.zeros((max_cells,
-                                 n_frames,
-                                 3), dtype=np.float32)
+        morphologies = np.zeros((n_frames, max_cells, 3), dtype=np.float32)
 
-        centroids = np.zeros((max_cells,
-                              n_frames,
-                              2), dtype=np.float32)
+        centroids = np.zeros((n_frames, max_cells, 2), dtype=np.float32)
 
-        adj_matrix = np.zeros((max_cells,
-                               max_cells,
-                               n_frames), dtype=np.float32)
+        adj_matrix = np.zeros((n_frames, max_cells, max_cells),
+                              dtype=np.float32)
 
         for frame in range(n_frames):
 
@@ -223,13 +218,13 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                 self.idx_to_id[(frame, cell_idx)] = cell_id
 
             num_tracks = len(frame_features['labels'])
-            centroids[:num_tracks, frame] = frame_features['centroids']
-            morphologies[:num_tracks, frame] = frame_features['morphologies']
-            appearances[:num_tracks, frame] = frame_features['appearances']
+            centroids[frame, :num_tracks] = frame_features['centroids']
+            morphologies[frame, :num_tracks] = frame_features['morphologies']
+            appearances[frame, :num_tracks] = frame_features['appearances']
 
-            cent = centroids[:, frame]
+            cent = centroids[frame]
             distance = cdist(cent, cent, metric='euclidean') < self.distance_threshold
-            adj_matrix[..., frame] = distance.astype('float32')
+            adj_matrix[frame] = distance.astype('float32')
 
         # Normalize adj matrix
         norm_adj_matrices = normalize_adj_matrix(adj_matrix)
@@ -239,29 +234,18 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
     def _get_neighborhood_embeddings(self, appearances, morphologies,
                                      centroids, adj_matrices):
         """Compute the embeddings using the neighborhood encoder"""
-
-        # Move the time dimension to the batch dimension
-        # DVV Note - if we moved the time dimension ahead of the cells dimension
-        # we wouldnt need to do all of this
-        app = np.transpose(appearances, axes=(1, 0, 2, 3, 4))
-        morph = np.transpose(morphologies, axes=(1, 0, 2))
-        cent = np.transpose(centroids, axes=(1, 0, 2))
-        adj = np.transpose(adj_matrices, axes=(2, 0, 1))
-
-        # Compute embedding
-        inputs = {'encoder_app_input': app,
-                  'encoder_morph_input': morph,
-                  'encoder_centroid_input': cent,
-                  'encoder_adj_input': adj}
+        # Build input ditionary for neighborhood encoder model
+        inputs = {
+            'encoder_app_input': appearances,
+            'encoder_morph_input': morphologies,
+            'encoder_centroid_input': centroids,
+            'encoder_adj_input': adj_matrices,
+        }
 
         # TODO: current model doesnt organize outputs according to ordered list
         #       patching with embedding_axis
         embeddings = self.neighborhood_encoder.predict(inputs)[self.embedding_axis]
         embeddings = np.array(embeddings)
-
-        # Reorder the time dimension
-        embeddings = np.transpose(embeddings, axes=(1, 0, 2))
-
         return embeddings
 
     def _validate_feature_name(self, feature_name):
@@ -274,7 +258,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         """Get the feature for a cell in the frame"""
         self._validate_feature_name(feature_name)
         cell_idx = self.id_to_idx[cell_id]
-        return self.features[feature_name][cell_idx, frame, :]
+        return self.features[feature_name][frame, cell_idx, :]
 
     def _get_frame_features(self, frame, feature_name='embedding'):
         """Get the feature for the specified cells in a frame"""
@@ -478,7 +462,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         # Perform inference
         predictions = self.tracking_model.predict(inputs)
-        predictions = predictions[0, :, :, 0, ...]  # Remove the batch and time dimension
+        predictions = predictions[0, 0, ...]  # Remove the batch and time dimension
         assignment_matrix = 1 - predictions[..., 0]
 
         for track_id in relevant_tracks:

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -234,7 +234,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
     def _get_neighborhood_embeddings(self, appearances, morphologies,
                                      centroids, adj_matrices):
         """Compute the embeddings using the neighborhood encoder"""
-        # Build input ditionary for neighborhood encoder model
+        # Build input dictionary for neighborhood encoder model
         inputs = {
             'encoder_app_input': appearances,
             'encoder_morph_input': morphologies,

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -588,7 +588,6 @@ class Track(object):  # pylint: disable=useless-object-inheritance
         self.temporal_adj_matrices = features_dict['temporal_adj_matrix']
         self.mask = features_dict['mask']
         self.track_length = features_dict['track_length']
-        self.time_axis = 2  # TODO: convert to 1 to resolve reshape issues.
 
     def _correct_lineages(self):
         """Ensure sequential labels for all batches"""
@@ -638,7 +637,7 @@ class Track(object):  # pylint: disable=useless-object-inheritance
         n_frames = self.X.shape[1]
         n_channels = self.X.shape[-1]
 
-        batch_shape = (n_batches, max_tracks, n_frames)
+        batch_shape = (n_batches, n_frames, max_tracks)
 
         appearance_shape = (self.appearance_dim, self.appearance_dim, n_channels)
 
@@ -648,7 +647,7 @@ class Track(object):  # pylint: disable=useless-object-inheritance
 
         centroids = np.zeros(batch_shape + (2,), dtype='float32')
 
-        adj_matrix = np.zeros((n_batches, max_tracks, max_tracks, n_frames), dtype='float32')
+        adj_matrix = np.zeros((n_batches, n_frames, max_tracks, max_tracks), dtype='float32')
 
         temporal_adj_matrix = np.zeros((n_batches,
                                         max_tracks,
@@ -676,10 +675,10 @@ class Track(object):  # pylint: disable=useless-object-inheritance
 
                 # Get adjacency matrix, cannot filter on track ids.
                 # TODO: different results if calculated in get_frame_features.
-                cent = centroids[batch, frame, :, :]
+                cent = centroids[batch, frame]
                 distance = cdist(cent, cent, metric='euclidean')
                 distance = distance < self.distance_threshold
-                adj_matrix[batch, frame, ...] = distance.astype(np.float32)
+                adj_matrix[batch, frame] = distance.astype(np.float32)
 
             # Get track length and temporal adjacency matrix
             for label in self.lineages[batch]:

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -339,7 +339,7 @@ def normalize_adj_matrix(adj, epsilon=1e-5):
         # temporarily include a batch dimension for consistent processing
         adj = np.expand_dims(adj, axis=0)
 
-    normed_adj = np.zeros(adj.shape, dtype=adj.dtype)
+    normed_adj = np.zeros(adj.shape, dtype='float32')
 
     for t in range(adj.shape[1]):
         adj_frame = adj[:, t]

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -342,7 +342,7 @@ def normalize_adj_matrix(adj, epsilon=1e-5):
         # temporarily include a batch dimension for consistent processing
         adj = np.expand_dims(adj, axis=0)
 
-    normed_adj = np.zeros(adj.shape, dtype='float32')
+    normalized_adj = np.zeros(adj.shape, dtype='float32')
 
     for t in range(adj.shape[1]):
         adj_frame = adj[:, t]
@@ -352,15 +352,15 @@ def normalize_adj_matrix(adj, epsilon=1e-5):
             degree = (degree + epsilon) ** -0.5
             degree_matrix = np.diagflat(degree)
 
-            norm_adj = np.matmul(degree_matrix, adj_frame[batch])
-            norm_adj = np.matmul(norm_adj, degree_matrix)
-            normed_adj[batch, t] = norm_adj
+            normalized = np.matmul(degree_matrix, adj_frame[batch])
+            normalized = np.matmul(normalized, degree_matrix)
+            normalized_adj[batch, t] = normalized
 
     if input_rank == 3:
         # remove batch axis
-        normed_adj = normed_adj[0]
+        normalized_adj = normalized_adj[0]
 
-    return normed_adj
+    return normalized_adj
 
 
 def relabel_sequential_lineage(y, lineage):

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -650,9 +650,9 @@ class Track(object):  # pylint: disable=useless-object-inheritance
         adj_matrix = np.zeros((n_batches, n_frames, max_tracks, max_tracks), dtype='float32')
 
         temporal_adj_matrix = np.zeros((n_batches,
-                                        max_tracks,
-                                        max_tracks,
                                         n_frames - 1,
+                                        max_tracks,
+                                        max_tracks,
                                         3), dtype='float32')
 
         mask = np.zeros(batch_shape, dtype='float32')

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -337,7 +337,7 @@ def normalize_adj_matrix(adj, epsilon=1e-5):
     for t in range(adj.shape[-3]):  # count backwards to ensure time axis
         adj_frame = adj[..., t, : , :]
         # setup degree matrix
-        degree_matrix = np.zeros(adj_frame.shape, dtype=np.float32)
+        degree_matrix = np.zeros(adj_frame.shape, dtype=normed_adj.dtype)
         # determine whether multiple batches being normalized
         if len(adj.shape) == 4:
             # adj is (batch, time, node, node)
@@ -346,8 +346,10 @@ def normalize_adj_matrix(adj, epsilon=1e-5):
                 degree = (degree + epsilon) ** -0.5
                 degree_matrix[batch] = np.diagflat(degree)
 
+            normed_adj[..., t, :, :] = degree_matrix
+
         elif len(adj.shape) == 3:
-            # adj is (cells, time, cells)
+            # adj is (time, cells, cells)
             norm_adj = np.matmul(degree_matrix, adj_frame)
             norm_adj = np.matmul(norm_adj, degree_matrix)
             normed_adj[t] = norm_adj

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -330,6 +330,9 @@ def normalize_adj_matrix(adj, epsilon=1e-5):
 
     Returns:
         np.array: Normalized adjacency matrix
+
+    Raises:
+        ValueError: If ``adj`` has a rank that is not 3 or 4.
     """
     input_rank = len(adj.shape)
     if input_rank not in {3, 4}:
@@ -343,17 +346,15 @@ def normalize_adj_matrix(adj, epsilon=1e-5):
 
     for t in range(adj.shape[1]):
         adj_frame = adj[:, t]
-        # setup degree matrix
-        degree_matrix = np.zeros(adj_frame.shape, dtype=normed_adj.dtype)
-        # adj is (batch, time, node, node)
+        # create degree matrix
         degrees = np.sum(adj_frame, axis=1)
         for batch, degree in enumerate(degrees):
             degree = (degree + epsilon) ** -0.5
-            degree_matrix[batch] = np.diagflat(degree)
+            degree_matrix = np.diagflat(degree)
 
-        norm_adj = np.matmul(degree_matrix, adj_frame)
-        norm_adj = np.matmul(norm_adj, degree_matrix)
-        normed_adj[:, t] = norm_adj
+            norm_adj = np.matmul(degree_matrix, adj_frame[batch])
+            norm_adj = np.matmul(norm_adj, degree_matrix)
+            normed_adj[batch, t] = norm_adj
 
     if input_rank == 3:
         # remove batch axis

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -713,7 +713,7 @@ class Track(object):  # pylint: disable=useless-object-inheritance
             temporal_adj_matrix[batch, ..., 1] = 1 - same_prob - daughter_prob
 
             # Identify padding
-            for i in range(temporal_adj_matrix.shape[1]):
+            for i in range(temporal_adj_matrix.shape[2]):
                 # index + 1 is the cell label
                 if i + 1 not in self.lineages[batch]:
                     temporal_adj_matrix[batch, :, i] = -1

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -647,7 +647,7 @@ class Track(object):  # pylint: disable=useless-object-inheritance
 
         centroids = np.zeros(batch_shape + (2,), dtype='float32')
 
-        adj_matrix = np.zeros((n_batches, n_frames, max_tracks, max_tracks), dtype='float32')
+        adj_matrix = np.zeros(batch_shape + (max_tracks,), dtype='float32')
 
         temporal_adj_matrix = np.zeros((n_batches,
                                         n_frames - 1,
@@ -666,7 +666,6 @@ class Track(object):  # pylint: disable=useless-object-inheritance
                     self.X[batch, frame], self.y[batch, frame],
                     appearance_dim=self.appearance_dim)
 
-                # TODO: convert to (batch, frame, track_id)
                 track_ids = frame_features['labels'] - 1
                 centroids[batch, frame, track_ids] = frame_features['centroids']
                 morphologies[batch, frame, track_ids] = frame_features['morphologies']
@@ -674,7 +673,6 @@ class Track(object):  # pylint: disable=useless-object-inheritance
                 mask[batch, frame, track_ids] = 1
 
                 # Get adjacency matrix, cannot filter on track ids.
-                # TODO: different results if calculated in get_frame_features.
                 cent = centroids[batch, frame]
                 distance = cdist(cent, cent, metric='euclidean')
                 distance = distance < self.distance_threshold

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -161,6 +161,14 @@ class TestTrackingUtils(object):
                 batched_normalized[b],
                 normalized)
 
+        # Should fail with too large inputs
+        with pytest.raises(ValueError):
+            utils.normalize_adj_matrix(np.zeros((32,) * 2))
+
+        # Should fail with too small inputs
+        with pytest.raises(ValueError):
+            utils.normalize_adj_matrix(np.zeros((32,) * 5))
+
     def test_get_max_cells(self):
         labels_per_frame = 5
         frames = 2

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -140,6 +140,27 @@ class TestTrackingUtils(object):
                 if exc.errno != errno.ENOENT:  # no such file or directory
                     raise  # re-raise exception
 
+    def test_normalize_adj_matrix(self):
+        frames = 3
+        # 2 cells in each frame
+        adj = np.zeros((frames, 2, 2))
+        for i in range(2):
+            adj[:, i, i] = 1
+
+        normalized = utils.normalize_adj_matrix(adj)
+
+        # TODO: check accuracy of normalized tensor.
+
+        # also normalize batches
+        batched_adj = np.stack([adj, adj], axis=0)
+        batched_normalized = utils.normalize_adj_matrix(batched_adj)
+
+        # each batch is the same, should be normalized consistently
+        for b in range(batched_normalized.shape[0]):
+            np.testing.assert_array_equal(
+                batched_normalized[b],
+                normalized)
+
     def test_get_max_cells(self):
         labels_per_frame = 5
         frames = 2


### PR DESCRIPTION
Previously, the appearance (and all other features) had a shape of:

```
(batch, maxObjects, frames, appearance_dim, appearance_dim, channels)
```

But the neighborhood encoder requires inputs with the time dimension first (in order to keep each frame independent of each other).

This PR updates all input and output arrays to expect the time axis to be first, as the neighborhood encoder requires. The new appearance shape is:

```
(batch, frames, maxObjects, appearance_dim, appearance_dim, channels)
```