### PR TITLE
Bump deepcell-toolbox to 0.10.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
     readme = f.read()
 
 
-VERSION = '0.4.0'
+VERSION = '0.4.1'
 NAME = 'DeepCell_Tracking'
 DESCRIPTION = 'Tracking cells and lineage with deep learning.'
 LICENSE = 'LICENSE'
@@ -62,7 +62,7 @@ setup(name=NAME,
                         'pathlib',
                         'scipy',
                         'scikit-image>=0.14.5',
-                        'deepcell-toolbox>=0.9.0,<0.10.0'],
+                        'deepcell-toolbox~=0.10.0'],
       extras_require={
           'tests': ['pytest<6',
                     'pytest-pep8',


### PR DESCRIPTION
This PR bumps the `deepcell-toolbox` dependency to 0.10.0.