### PR TITLE
Compress `.trks` by using `gzip` compression when writing the tarfile.

### DIFF
--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -747,7 +747,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         filename = str(filename)
 
-        with tarfile.open(filename, 'w:gz') as trks:
+        with tarfile.open(filename, 'w:bz2') as trks:
             # disable auto deletion and close/delete manually
             # to resolve double-opening issue on Windows.
             with tempfile.NamedTemporaryFile('w', delete=False) as lineage:

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -747,7 +747,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         filename = str(filename)
 
-        with tarfile.open(filename, 'w:bz2') as trks:
+        with tarfile.open(filename, 'w:gz') as trks:
             # disable auto deletion and close/delete manually
             # to resolve double-opening issue on Windows.
             with tempfile.NamedTemporaryFile('w', delete=False) as lineage:

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -757,19 +757,14 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
                 trks.add(lineage.name, 'lineage.json')
                 os.remove(lineage.name)
 
-            with tempfile.NamedTemporaryFile(delete=False) as raw:
-                np.save(raw, track_review_dict['X'])
-                raw.flush()
-                raw.close()
-                trks.add(raw.name, 'raw.npy')
-                os.remove(raw.name)
-
-            with tempfile.NamedTemporaryFile(delete=False) as tracked:
-                np.save(tracked, track_review_dict['y_tracked'])
-                tracked.flush()
-                tracked.close()
-                trks.add(tracked.name, 'tracked.npy')
-                os.remove(tracked.name)
+            with tempfile.NamedTemporaryFile(delete=False) as npz_file:
+                raw = track_review_dict['X']
+                tracked = track_review_dict['y_tracked']
+                np.savez_compressed(npz_file, X=raw, y=tracked)
+                npz_file.flush()
+                npz_file.close()
+                trks.add(npz_file.name, 'data.npz')
+                os.remove(npz_file.name)
 
     def _track_to_graph(self, tracks):
         """Create a graph from the lineage information"""

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -747,7 +747,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         filename = str(filename)
 
-        with tarfile.open(filename, 'w') as trks:
+        with tarfile.open(filename, 'w:gz') as trks:
             # disable auto deletion and close/delete manually
             # to resolve double-opening issue on Windows.
             with tempfile.NamedTemporaryFile('w', delete=False) as lineage:

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -209,7 +209,7 @@ def save_trks(filename, lineages, raw, tracked):
     if not str(filename).lower().endswith('.trks'):
         raise ValueError('filename must end with `.trks`. Found %s' % filename)
 
-    with tarfile.open(filename, 'w:bz2') as trks:
+    with tarfile.open(filename, 'w:gz') as trks:
         with tempfile.NamedTemporaryFile('w', delete=False) as lineages_file:
             json.dump(lineages, lineages_file, indent=4)
             lineages_file.flush()

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -209,7 +209,7 @@ def save_trks(filename, lineages, raw, tracked):
     if not str(filename).lower().endswith('.trks'):
         raise ValueError('filename must end with `.trks`. Found %s' % filename)
 
-    with tarfile.open(filename, 'w') as trks:
+    with tarfile.open(filename, 'w:gz') as trks:
         with tempfile.NamedTemporaryFile('w', delete=False) as lineages_file:
             json.dump(lineages, lineages_file, indent=4)
             lineages_file.flush()

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -209,7 +209,7 @@ def save_trks(filename, lineages, raw, tracked):
     if not str(filename).lower().endswith('.trks'):
         raise ValueError('filename must end with `.trks`. Found %s' % filename)
 
-    with tarfile.open(filename, 'w:gz') as trks:
+    with tarfile.open(filename, 'w:bz2') as trks:
         with tempfile.NamedTemporaryFile('w', delete=False) as lineages_file:
             json.dump(lineages, lineages_file, indent=4)
             lineages_file.flush()

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -29,10 +29,7 @@ from __future__ import division
 from __future__ import print_function
 
 import copy
-import errno
 import os
-import shutil
-import tempfile
 
 import numpy as np
 import skimage as sk
@@ -144,33 +141,25 @@ class TestTrackingUtils(object):
             y, same_probability=prob, data_format='channels_first')
         assert pairs == expected
 
-    def test_save_trks(self):
+    def test_save_trks(self, tmpdir):
         X = get_image(30, 30)
         y = np.random.randint(low=0, high=10, size=X.shape)
         lineage = [dict()]
 
-        try:
-            tempdir = tempfile.mkdtemp()  # create dir
-            with pytest.raises(ValueError):
-                badfilename = os.path.join(tempdir, 'x.trk')
-                utils.save_trks(badfilename, lineage, X, y)
+        tempdir = str(tmpdir)  # create dir
+        with pytest.raises(ValueError):
+            badfilename = os.path.join(tempdir, 'x.trk')
+            utils.save_trks(badfilename, lineage, X, y)
 
-            filename = os.path.join(tempdir, 'x.trks')
-            utils.save_trks(filename, lineage, X, y)
-            assert os.path.isfile(filename)
+        filename = os.path.join(tempdir, 'x.trks')
+        utils.save_trks(filename, lineage, X, y)
+        assert os.path.isfile(filename)
 
-            # test saved tracks can be loaded
-            loaded = utils.load_trks(filename)
-            assert loaded['lineages'] == lineage
-            np.testing.assert_array_equal(X, loaded['X'])
-            np.testing.assert_array_equal(y, loaded['y'])
-
-        finally:
-            try:
-                shutil.rmtree(tempdir)  # delete directory
-            except OSError as exc:
-                if exc.errno != errno.ENOENT:  # no such file or directory
-                    raise  # re-raise exception
+        # test saved tracks can be loaded
+        loaded = utils.load_trks(filename)
+        assert loaded['lineages'] == lineage
+        np.testing.assert_array_equal(X, loaded['X'])
+        np.testing.assert_array_equal(y, loaded['y'])
 
     def test_normalize_adj_matrix(self):
         frames = 3


### PR DESCRIPTION
`tarfile` supports `w:gz` as a write mode which should enable compression with better backward compatibility than changing the interior file structure (see #62).