### PR TITLE
Support saving and loading trk/trks data to/from `BytesIO`

### DIFF
--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -50,6 +50,7 @@ from deepcell_tracking.utils import clean_up_annotations
 from deepcell_tracking.utils import get_max_cells
 from deepcell_tracking.utils import normalize_adj_matrix
 from deepcell_tracking.utils import get_image_features
+from deepcell_tracking.utils import save_trk
 
 
 class CellTracker(object):  # pylint: disable=useless-object-inheritance
@@ -747,29 +748,10 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
 
         filename = str(filename)
 
-        with tarfile.open(filename, 'w:gz') as trks:
-            # disable auto deletion and close/delete manually
-            # to resolve double-opening issue on Windows.
-            with tempfile.NamedTemporaryFile('w', delete=False) as lineage:
-                json.dump(track_review_dict['tracks'], lineage, indent=4)
-                lineage.flush()
-                lineage.close()
-                trks.add(lineage.name, 'lineage.json')
-                os.remove(lineage.name)
-
-            with tempfile.NamedTemporaryFile(delete=False) as raw:
-                np.save(raw, track_review_dict['X'])
-                raw.flush()
-                raw.close()
-                trks.add(raw.name, 'raw.npy')
-                os.remove(raw.name)
-
-            with tempfile.NamedTemporaryFile(delete=False) as tracked:
-                np.save(tracked, track_review_dict['y_tracked'])
-                tracked.flush()
-                tracked.close()
-                trks.add(tracked.name, 'tracked.npy')
-                os.remove(tracked.name)
+        save_trk(filename=filename,
+                 lineages=track_review_dict['tracks'],
+                 raw=track_review_dict['X'],
+                 tracked=track_review_dict['y_tracked'])
 
     def _track_to_graph(self, tracks):
         """Create a graph from the lineage information"""

--- a/deepcell_tracking/tracking.py
+++ b/deepcell_tracking/tracking.py
@@ -749,7 +749,7 @@ class CellTracker(object):  # pylint: disable=useless-object-inheritance
         filename = str(filename)
 
         save_trk(filename=filename,
-                 lineages=track_review_dict['tracks'],
+                 lineage=track_review_dict['tracks'],
                  raw=track_review_dict['X'],
                  tracked=track_review_dict['y_tracked'])
 

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -203,7 +203,7 @@ def trk_folder_to_trks(dirname, trks_filename):
 
 
 def save_trks(filename, lineages, raw, tracked):
-    """Saves raw, tracked, and lineage data into one trks_file.
+    """Saves raw, tracked, and lineage data from multiple movies into one trks_file.
 
     Args:
         filename (str or io.BytesIO): full path to the final trk files or bytes object
@@ -227,7 +227,7 @@ def save_trks(filename, lineages, raw, tracked):
 
 
 def save_trk(filename, lineages, raw, tracked):
-    """Saves raw, tracked, and lineage data into a trk_file.
+    """Saves raw, tracked, and lineage data for one movie into a trk_file.
 
     Args:
         filename (str or io.BytesIO): full path to the final trk files or bytes

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -254,7 +254,7 @@ def save_trk(filename, lineages, raw, tracked):
     if isinstance(lineages, list):
         if len(lineages) > 1:
             raise ValueError('For trk file, lineages must be a dictionary '
-                            'or list with a single dictionary')
+                             'or list with a single dictionary')
         else:
             lineages = lineages[0]
 

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -278,6 +278,8 @@ def save_track_data(filename, lineages, raw, tracked, lineage_name):
         kwargs = {'name': filename}
 
     with tarfile.open(mode='w:gz', **kwargs) as trks:
+        # disable auto deletion and close/delete manually
+        # to resolve double-opening issue on Windows.
         with tempfile.NamedTemporaryFile('w', delete=False) as lineages_file:
             json.dump(lineages, lineages_file, indent=4)
             lineages_file.flush()

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -222,12 +222,11 @@ def save_trks(filename, lineages, raw, tracked):
     if not isinstance(filename, io.BytesIO) and ext != '.trks':
         raise ValueError('filename must end with `.trks`. Found %s' % filename)
 
-    out = save_track_data(filename=filename,
-                          lineages=lineages,
-                          raw=raw,
-                          tracked=tracked,
-                          lineage_name='lineages.json')
-    return out
+    save_track_data(filename=filename,
+                    lineages=lineages,
+                    raw=raw,
+                    tracked=tracked,
+                    lineage_name='lineages.json')
 
 
 def save_trk(filename, lineages, raw, tracked):
@@ -258,12 +257,11 @@ def save_trk(filename, lineages, raw, tracked):
         else:
             lineages = lineages[0]
 
-    out = save_track_data(filename=filename,
-                          lineages=lineages,
-                          raw=raw,
-                          tracked=tracked,
-                          lineage_name='lineage.json')
-    return out
+    save_track_data(filename=filename,
+                    lineages=lineages,
+                    raw=raw,
+                    tracked=tracked,
+                    lineage_name='lineage.json')
 
 
 def save_track_data(filename, lineages, raw, tracked, lineage_name):
@@ -277,9 +275,6 @@ def save_track_data(filename, lineages, raw, tracked, lineage_name):
         tracked (np.array): annotated image data.
         lineage_name (str): Filename for the lineage file in the tarfile, either 'lineages.json'
             or 'lineage.json'
-
-    Returns:
-        io.BytesIO: If filename is instance of io.BytesIO
     """
 
     if isinstance(filename, io.BytesIO):
@@ -308,10 +303,6 @@ def save_track_data(filename, lineages, raw, tracked, lineage_name):
             tracked_file.close()
             trks.add(tracked_file.name, 'tracked.npy')
             os.remove(tracked_file.name)
-
-    if isinstance(filename, io.BytesIO):
-        filename.seek(0)
-        return filename
 
 
 def trks_stats(filename):

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -212,9 +212,6 @@ def save_trks(filename, lineages, raw, tracked):
         raw (np.array): raw images data.
         tracked (np.array): annotated image data.
 
-    Returns:
-        io.BytesIO: If filename is instance of io.BytesIO
-
     Raises:
         ValueError: filename does not end in ".trks".
     """
@@ -233,14 +230,12 @@ def save_trk(filename, lineages, raw, tracked):
     """Saves raw, tracked, and lineage data into a trk_file.
 
     Args:
-        filename (str or io.BytesIO): full path to the final trk files or bytes object
-            to save the data to
-        lineages (list or dict): a list of a single dictionary or a single lineage dictionarys
+        filename (str or io.BytesIO): full path to the final trk files or bytes
+            object to save the data to
+        lineages (list or dict): a list of a single dictionary or a single
+            lineage dictionary
         raw (np.array): raw images data.
         tracked (np.array): annotated image data.
-
-    Returns:
-        io.BytesIO: If filename is instance of io.BytesIO
 
     Raises:
         ValueError: filename does not end in ".trks".

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -218,12 +218,16 @@ def save_trks(filename, lineages, raw, tracked):
     Raises:
         ValueError: filename does not end in ".trks".
     """
-    if not str(filename).lower().endswith('.trks') and not isinstance(filename, io.BytesIO):
+    ext = os.path.splitext(str(filename))[-1]
+    if not isinstance(filename, io.BytesIO) and ext != '.trks':
         raise ValueError('filename must end with `.trks`. Found %s' % filename)
 
-    out = save_track_data(filename, lineages, raw, tracked, 'lineages.json')
-    if out is not None:
-        return out
+    out = save_track_data(filename=filename,
+                          lineages=lineages,
+                          raw=raw,
+                          tracked=tracked,
+                          lineage_name='lineages.json')
+    return out
 
 
 def save_trk(filename, lineages, raw, tracked):
@@ -242,8 +246,8 @@ def save_trk(filename, lineages, raw, tracked):
     Raises:
         ValueError: filename does not end in ".trks".
     """
-
-    if not str(filename).lower().endswith('.trk') and not isinstance(filename, io.BytesIO):
+    ext = os.path.splitext(str(filename))[-1]
+    if not isinstance(filename, io.BytesIO) and ext != '.trk':
         raise ValueError('filename must end with `.trk`. Found %s' % filename)
 
     # Check that lineages is a dictionary or list of length 1
@@ -254,9 +258,12 @@ def save_trk(filename, lineages, raw, tracked):
         else:
             lineages = lineages[0]
 
-    out = save_track_data(filename, lineages, raw, tracked, 'lineage.json')
-    if out is not None:
-        return out
+    out = save_track_data(filename=filename,
+                          lineages=lineages,
+                          raw=raw,
+                          tracked=tracked,
+                          lineage_name='lineage.json')
+    return out
 
 
 def save_track_data(filename, lineages, raw, tracked, lineage_name):

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -226,7 +226,7 @@ def save_trks(filename, lineages, raw, tracked):
                     lineage_name='lineages.json')
 
 
-def save_trk(filename, lineages, raw, tracked):
+def save_trk(filename, lineage, raw, tracked):
     """Saves raw, tracked, and lineage data for one movie into a trk_file.
 
     Args:
@@ -245,15 +245,15 @@ def save_trk(filename, lineages, raw, tracked):
         raise ValueError('filename must end with `.trk`. Found %s' % filename)
 
     # Check that lineages is a dictionary or list of length 1
-    if isinstance(lineages, list):
-        if len(lineages) > 1:
+    if isinstance(lineage, list):
+        if len(lineage) > 1:
             raise ValueError('For trk file, lineages must be a dictionary '
                              'or list with a single dictionary')
         else:
-            lineages = lineages[0]
+            lineage = lineage[0]
 
     save_track_data(filename=filename,
-                    lineages=lineages,
+                    lineages=lineage,
                     raw=raw,
                     tracked=tracked,
                     lineage_name='lineage.json')

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 
 import copy
 import os
+import io
 
 import numpy as np
 import skimage as sk
@@ -157,6 +158,17 @@ class TestTrackingUtils(object):
 
         # test saved tracks can be loaded
         loaded = utils.load_trks(filename)
+        assert loaded['lineages'] == lineage
+        np.testing.assert_array_equal(X, loaded['X'])
+        np.testing.assert_array_equal(y, loaded['y'])
+
+        # test save trks to bytes
+        b = io.BytesIO()
+        out = utils.save_trks(b, lineage, X, y)
+        assert isinstance(out, io.BytesIO)
+
+        # load trks from bytes
+        loaded = utils.load_trks(out)
         assert loaded['lineages'] == lineage
         np.testing.assert_array_equal(X, loaded['X'])
         np.testing.assert_array_equal(y, loaded['y'])

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -183,6 +183,9 @@ class TestTrackingUtils(object):
             badfilename = os.path.join(tempdir, 'x.trks')
             utils.save_trk(badfilename, lineage, X, y)
 
+        with pytest.raises(ValueError):
+            utils.save_trk('x.trk', [{}, {}], X, y)
+
         filename = os.path.join(tempdir, 'x.trk')
         utils.save_trk(filename, lineage, X, y)
         assert os.path.isfile(filename)
@@ -203,6 +206,21 @@ class TestTrackingUtils(object):
         assert loaded['lineages'] == lineage
         np.testing.assert_array_equal(X, loaded['X'])
         np.testing.assert_array_equal(y, loaded['y'])
+
+    def test_load_trks(self, tmpdir):
+        filename = os.path.join(str(tmpdir), 'bad-lineage.trk')
+        X = get_image(30, 30)
+        y = np.random.randint(low=0, high=10, size=X.shape)
+        lineage = [dict()]
+
+        utils.save_track_data(filename=filename,
+                              lineages=lineage,
+                              raw=X,
+                              tracked=y,
+                              lineage_name='bad-lineage.json')
+
+        with pytest.raises(ValueError):
+            utils.load_trks(filename)
 
     def test_normalize_adj_matrix(self):
         frames = 3
@@ -393,6 +411,12 @@ class TestTrackingUtils(object):
         # test that input must be iterable
         with pytest.raises(TypeError):
             utils.concat_tracks(track_1)
+
+    def test_trks_stats(self):
+
+        # Test bad extension
+        with pytest.raises(ValueError):
+            utils.trks_stats('bad-extension.npz')
 
 
 class TestTrack(object):

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -164,11 +164,42 @@ class TestTrackingUtils(object):
 
         # test save trks to bytes
         b = io.BytesIO()
-        out = utils.save_trks(b, lineage, X, y)
-        assert isinstance(out, io.BytesIO)
+        utils.save_trks(b, lineage, X, y)
 
         # load trks from bytes
-        loaded = utils.load_trks(out)
+        b.seek(0)
+        loaded = utils.load_trks(b)
+        assert loaded['lineages'] == lineage
+        np.testing.assert_array_equal(X, loaded['X'])
+        np.testing.assert_array_equal(y, loaded['y'])
+
+    def test_save_trk(self, tmpdir):
+        X = get_image(30, 30)
+        y = np.random.randint(low=0, high=10, size=X.shape)
+        lineage = [dict()]
+
+        tempdir = str(tmpdir)
+        with pytest.raises(ValueError):
+            badfilename = os.path.join(tempdir, 'x.trks')
+            utils.save_trk(badfilename, lineage, X, y)
+
+        filename = os.path.join(tempdir, 'x.trk')
+        utils.save_trk(filename, lineage, X, y)
+        assert os.path.isfile(filename)
+
+        # test saved tracks can be loaded
+        loaded = utils.load_trks(filename)
+        assert loaded['lineages'] == lineage
+        np.testing.assert_array_equal(X, loaded['X'])
+        np.testing.assert_array_equal(y, loaded['y'])
+
+        # test save trks to bytes
+        b = io.BytesIO()
+        utils.save_trk(b, lineage, X, y)
+
+        # load trks from bytes
+        b.seek(0)
+        loaded = utils.load_trks(b)
         assert loaded['lineages'] == lineage
         np.testing.assert_array_equal(X, loaded['X'])
         np.testing.assert_array_equal(y, loaded['y'])


### PR DESCRIPTION
In the `data-registry`, we often read and write track data in memory in order to facilitate moving data to and from s3 buckets. This PR enables a `io.BytesIO()` object to be passed into `save_trks` and `load_trks` in place of a filepath. Additionally a new utility function `save_track_data` is introduced to serve as a base for `save_trks` and `save_trk` which are wrappers that allow saving to either `trk` or `trks`.