### PR TITLE
`is_valid_lineage` should check if the daughter ID is valid.

### DIFF
--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -482,7 +482,7 @@ def is_valid_lineage(lineage):
     Returns:
         bool: Whether or not the lineage is valid.
     """
-    for cell_lineage in lineage.values():
+    for cell_label, cell_lineage in lineage.items():
         # Get last frame of parent
         last_parent_frame = cell_lineage['frames'][-1]
 
@@ -492,7 +492,7 @@ def is_valid_lineage(lineage):
                 first_daughter_frame = lineage[daughter]['frames'][0]
             except KeyError:
                 warnings.warn('lineage {} has invalid daughters: {}'.format(
-                    cell_lineage['label'], cell_lineage['daughters']))
+                    cell_label, cell_lineage['daughters']))
                 return False
 
             # Check that daughter's start frame is one larger than parent end frame

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -349,6 +349,11 @@ class TestTrackingUtils(object):
         bad_lineage[2]['frames'] = [2]
         assert not utils.is_valid_lineage(bad_lineage)
 
+        # change one of cell 0's daughters to an invalid ID.
+        bad_lineage = copy.copy(lineage)
+        bad_lineage[0]['daughters'][0] = 3
+        assert not utils.is_valid_lineage(bad_lineage)
+
     def test_get_image_features(self):
         num_labels = 3
         y = get_annotated_image(num_labels=num_labels, sequential=True)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
     readme = f.read()
 
 
-VERSION = '0.4.4'
+VERSION = '0.4.5'
 NAME = 'DeepCell_Tracking'
 DESCRIPTION = 'Tracking cells and lineage with deep learning.'
 LICENSE = 'LICENSE'


### PR DESCRIPTION
If a cell's daughter ID is not a valid track ID, then `is_valid_lineage` will crash due to a `KeyError`. Instead, it should catch this error and note the lineage as invalid.