### PR TITLE
Improve error handling for `relabel_sequential_lineage` and `is_valid_lineage`

### DIFF
--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -461,7 +461,15 @@ def relabel_sequential_lineage(y, lineage):
 
         # Fix daughters
         daughters = lineage[cell_id]['daughters']
-        new_lineage[new_cell_id]['daughters'] = [fw[d] for d in daughters]
+        new_lineage[new_cell_id]['daughters'] = []
+        for d in daughters:
+            new_daughter = fw[d]
+            if not new_daughter:  # missing labels get mapped to 0
+                warnings.warn('Cell {} has daughter {} which is not found '
+                              'in the label image `y`.'.format(cell_id, d))
+
+            # TODO: should this be in an else block?
+            new_lineage[new_cell_id]['daughters'].append(new_daughter)
 
         # Fix frames
         y_true = np.sum(y == cell_id, axis=(1, 2))

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -325,34 +325,69 @@ class TestTrackingUtils(object):
             assert not new_lineage[d]['daughters']
 
     def test_is_valid_lineage(self):
-        lineage = {
-            0: {'frames': [0],
-                'daughters': [1, 2],
-                'capped': True,
-                'frame_div': 1,
-                'parent': None},
-            1: {'frames': [1],
-                'daughters': [],
-                'capped': False,
-                'frame_div': 1,
-                'parent': 0},
-            2: {'frames': [1],
-                'daughters': [],
-                'capped': False,
-                'frame_div': 1,
-                'parent': 0},
-        }
-        assert utils.is_valid_lineage(lineage)
+        image1 = get_annotated_image(num_labels=1, sequential=False)
+        image2 = get_annotated_image(num_labels=2, sequential=False)
+        movie = np.stack([image1, image2], axis=0)
 
-        # change cell 2's daughter frame to 2, should fail
-        bad_lineage = copy.copy(lineage)
-        bad_lineage[2]['frames'] = [2]
-        assert not utils.is_valid_lineage(bad_lineage)
+        # create dummy lineage
+        lineage = {}
+        for frame in range(movie.shape[0]):
+            unique_labels = np.unique(movie[frame])
+            unique_labels = unique_labels[unique_labels != 0]
+            for unique_label in unique_labels:
+                lineage[unique_label] = {
+                    'frames': [frame],
+                    'parent': None,
+                    'daughters': [],
+                    'label': unique_label,
+                }
 
-        # change one of cell 0's daughters to an invalid ID.
-        bad_lineage = copy.copy(lineage)
-        bad_lineage[0]['daughters'][0] = 3
-        assert not utils.is_valid_lineage(bad_lineage)
+        # assign parents and daughters
+        parent_label = np.unique(movie[0])
+        parent_label = parent_label[parent_label != 0][0]
+
+        daughter_labels = np.unique(movie[1])
+        daughter_labels = [d for d in daughter_labels if d]
+
+        lineage[parent_label]['daughters'] = daughter_labels
+        for d in daughter_labels:
+            lineage[d]['parent'] = parent_label
+
+        assert utils.is_valid_lineage(movie, lineage)
+
+        # a cell's frames should match the label array
+        bad_lineage = copy.deepcopy(lineage)
+        bad_lineage[parent_label]['frames'].append(1)
+        assert not utils.is_valid_lineage(movie, bad_lineage)
+
+        # a daughter's frames should start immediatlely
+        # after the parent's last frame
+        for bad_frame in [0, 2]:
+            bad_lineage = copy.deepcopy(lineage)
+            bad_lineage[daughter_labels[0]]['frames'] = [bad_frame]
+            assert not utils.is_valid_lineage(movie, bad_lineage)
+
+        # cell in lineage but not in movie is invalid
+        max_label = np.max(movie)
+        unique_labels = np.unique(movie)
+        unique_labels = unique_labels[unique_labels != 0]
+        bad_label = np.max(movie) + 1
+        bad_lineage = copy.deepcopy(lineage)
+        bad_lineage[bad_label] = bad_lineage[max_label]
+        assert not utils.is_valid_lineage(movie, bad_lineage)
+
+        # cell in movie but not in lineage is invalid
+        new_frame = get_annotated_image(num_labels=1, sequential=False)
+        bad_movie = np.concatenate([
+            movie,
+            np.expand_dims(new_frame, axis=0)
+        ], axis=0)
+        assert not utils.is_valid_lineage(bad_movie, lineage)
+
+        # all daughters must be in the lineage and in the movie
+        bad_lineage = copy.deepcopy(lineage)
+        bad_lineage[parent_label]['daughters'][0] = bad_label
+        assert not utils.is_valid_lineage(movie, bad_lineage)
 
     def test_get_image_features(self):
         num_labels = 3


### PR DESCRIPTION
`is_valid_lineage` only checks the lineage object itself. However, the lineage object is completely dependent on the `y` label mask. This function has been changed to require the `y` array, and is a much stronger validation of lineages. (Closes #72) This PR changes the `is_valid_lineage` signature, and should be considered a breaking change.

Additionally, `relabel_sequential` has been found to map unknown integers to 0. This caused some confusion that the original `.trk` file had a 0 as a daughter value. When this happens, `relabel_sequential_lineage` will warn the user that the value is getting mapped to 0. This will only happen with invalid lineages.

Finally, the `Track` object has been updated to only call `relabel_sequential_lineage` if the lineage is found to be valid. This should help reduce instantiation time by skipping the relabel step for invalid batches.
