### PR TITLE
Validate parent lineage field as well as daughters.

### DIFF
--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -535,6 +535,27 @@ def is_valid_lineage(y, lineage):
                     cell_label, daughter))
                 return False
 
+        # TODO: test parent in lineage
+        parent = cell_lineage.get('parent')
+        if parent:
+            try:
+                parent_lineage = lineage[parent]
+            except KeyError:
+                warnings.warn('Parent {} is not present in the lineage'.format(
+                    cell_lineage['parent']))
+                return False
+            try:
+                last_parent_frame = parent_lineage['frames'][-1]
+                first_daughter_frame = cell_lineage['frames'][0]
+            except IndexError:  # frames is empty?
+                warnings.warn('Cell {} has no frames'.format(parent))
+                return False
+            # Check that daughter's start frame is one larger than parent end frame
+            if first_daughter_frame - last_parent_frame != 1:
+                warnings.warn('lineage {} has daughter {} before parent.'.format(
+                    cell_label, daughter))
+                return False
+
     return True  # all cell lineages are valid!
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
     readme = f.read()
 
 
-VERSION = '0.5.0-rc.1'
+VERSION = '0.5.0-rc.2'
 NAME = 'DeepCell_Tracking'
 DESCRIPTION = 'Tracking cells and lineage with deep learning.'
 LICENSE = 'LICENSE'


### PR DESCRIPTION
#73 updated `is_valid_lineage` to do better of all cells. However, there is no extra validation of the `parent` field, which is used in the `isbi_utils` functions.

This PR adds some basic validation of the `parent` lineage field to improve the validation of the lineage objects.