### PR TITLE
Fix `norecursedirs` to ignore build directory

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,7 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 
 # Do not run tests in the build folder
-norecursedirs= build, .ipynb_checkpoints
+norecursedirs= build .ipynb_checkpoints
 
 # PEP-8 The following are ignored:
 # E501 line too long (82 > 79 characters)

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(name=NAME,
                         'scikit-image>=0.14.5',
                         'deepcell-toolbox~=0.10.0'],
       extras_require={
-          'tests': ['pytest<6',
+          'tests': ['pytest',
                     'pytest-pep8',
                     'pytest-cov',
                     'pytest-mock']},

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(name=NAME,
                         'scikit-image>=0.14.5',
                         'deepcell-toolbox~=0.10.0'],
       extras_require={
-          'tests': ['pytest',
+          'tests': ['pytest<6',
                     'pytest-pep8',
                     'pytest-cov',
                     'pytest-mock']},


### PR DESCRIPTION
Tests started failing due to a duplicate test event found in the `build` directory. This should be ignored in `pytest.ini`, but is an erroneous comma in the path. This PR fixes the `norecursedirs` setting.