### PR TITLE
Fix bug in `is_valid_lineage`; daughters can be < parent.

### DIFF
--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -488,13 +488,15 @@ def is_valid_lineage(y, lineage):
     all_cells = np.unique(y)
     all_cells = set([c for c in all_cells if c])
 
+    is_valid = True
+
     # every lineage should have valid fields
     for cell_label, cell_lineage in lineage.items():
         # Get last frame of parent
         if cell_label not in all_cells:
             warnings.warn('Cell {} not found in the label image.'.format(
                 cell_label))
-            return False
+            is_valid = False
 
         # any cells leftover are missing lineage
         all_cells.remove(cell_label)
@@ -505,7 +507,7 @@ def is_valid_lineage(y, lineage):
         frames = list(y_index)
         if frames != cell_lineage['frames']:
             warnings.warn('Cell {} has invalid frames'.format(cell_label))
-            return False
+            is_valid = False
 
         last_parent_frame = cell_lineage['frames'][-1]
 
@@ -513,20 +515,20 @@ def is_valid_lineage(y, lineage):
             if daughter not in lineage:
                 warnings.warn('lineage {} has invalid daughters: {}'.format(
                     cell_label, cell_lineage['daughters']))
-                return False
+                is_valid = False
 
             # get first frame of daughter
             try:
                 first_daughter_frame = lineage[daughter]['frames'][0]
             except IndexError:  # frames is empty?
                 warnings.warn('Daughter {} has no frames'.format(daughter))
-                return False
+                is_valid = False
 
             # Check that daughter's start frame is one larger than parent end frame
             if first_daughter_frame - last_parent_frame != 1:
                 warnings.warn('lineage {} has daughter {} before parent.'.format(
                     cell_label, daughter))
-                return False
+                is_valid = False
 
         # TODO: test parent in lineage
         parent = cell_lineage.get('parent')
@@ -536,13 +538,13 @@ def is_valid_lineage(y, lineage):
             except KeyError:
                 warnings.warn('Parent {} is not present in the lineage'.format(
                     cell_lineage['parent']))
-                return False
+                is_valid = False
             try:
                 last_parent_frame = parent_lineage['frames'][-1]
                 first_daughter_frame = cell_lineage['frames'][0]
             except IndexError:  # frames is empty?
                 warnings.warn('Cell {} has no frames'.format(parent))
-                return False
+                is_valid = False
             # Check that daughter's start frame is one larger than parent end frame
             if first_daughter_frame - last_parent_frame != 1:
                 warnings.warn(
@@ -550,14 +552,14 @@ def is_valid_lineage(y, lineage):
                     'appears in frame {}.'.format(
                         parent, last_parent_frame, cell_label,
                         first_daughter_frame))
-                return False
+                is_valid = False
 
     if all_cells:  # all cells with lineages should be removed
         warnings.warn('Cells missing their lineage: {}'.format(
             list(all_cells)))
-        return False
+        is_valid = False
 
-    return True  # all cell lineages are valid!
+    return is_valid  # if unchanged, all cell lineages are valid!
 
 
 def get_image_features(X, y, appearance_dim=32):

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -497,9 +497,10 @@ def is_valid_lineage(y, lineage):
             warnings.warn('Cell {} not found in the label image.'.format(
                 cell_label))
             is_valid = False
-
-        # any cells leftover are missing lineage
-        all_cells.remove(cell_label)
+        
+        else:
+            # any cells leftover are missing lineage
+            all_cells.remove(cell_label)
 
         # validate `frames`
         y_true = np.any(y == cell_label, axis=(1, 2))

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -510,7 +510,7 @@ def is_valid_lineage(y, lineage):
         last_parent_frame = cell_lineage['frames'][-1]
 
         for daughter in cell_lineage['daughters']:
-            if daughter not in all_cells or daughter not in lineage:
+            if daughter not in lineage:
                 warnings.warn('lineage {} has invalid daughters: {}'.format(
                     cell_label, cell_lineage['daughters']))
                 return False

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -497,10 +497,10 @@ def is_valid_lineage(y, lineage):
             warnings.warn('Cell {} not found in the label image.'.format(
                 cell_label))
             is_valid = False
-        
-        else:
-            # any cells leftover are missing lineage
-            all_cells.remove(cell_label)
+            continue
+
+        # any cells leftover are missing lineage
+        all_cells.remove(cell_label)
 
         # validate `frames`
         y_true = np.any(y == cell_label, axis=(1, 2))
@@ -509,6 +509,7 @@ def is_valid_lineage(y, lineage):
         if frames != cell_lineage['frames']:
             warnings.warn('Cell {} has invalid frames'.format(cell_label))
             is_valid = False
+            continue  # no need to test further
 
         last_parent_frame = cell_lineage['frames'][-1]
 
@@ -517,6 +518,7 @@ def is_valid_lineage(y, lineage):
                 warnings.warn('lineage {} has invalid daughters: {}'.format(
                     cell_label, cell_lineage['daughters']))
                 is_valid = False
+                continue  # no need to test further
 
             # get first frame of daughter
             try:
@@ -524,12 +526,14 @@ def is_valid_lineage(y, lineage):
             except IndexError:  # frames is empty?
                 warnings.warn('Daughter {} has no frames'.format(daughter))
                 is_valid = False
+                continue  # no need to test further
 
             # Check that daughter's start frame is one larger than parent end frame
             if first_daughter_frame - last_parent_frame != 1:
                 warnings.warn('lineage {} has daughter {} before parent.'.format(
                     cell_label, daughter))
                 is_valid = False
+                continue  # no need to test further
 
         # TODO: test parent in lineage
         parent = cell_lineage.get('parent')
@@ -540,12 +544,14 @@ def is_valid_lineage(y, lineage):
                 warnings.warn('Parent {} is not present in the lineage'.format(
                     cell_lineage['parent']))
                 is_valid = False
+                continue  # no need to test further
             try:
                 last_parent_frame = parent_lineage['frames'][-1]
                 first_daughter_frame = cell_lineage['frames'][0]
             except IndexError:  # frames is empty?
                 warnings.warn('Cell {} has no frames'.format(parent))
                 is_valid = False
+                continue  # no need to test further
             # Check that daughter's start frame is one larger than parent end frame
             if first_daughter_frame - last_parent_frame != 1:
                 warnings.warn(
@@ -554,6 +560,7 @@ def is_valid_lineage(y, lineage):
                         parent, last_parent_frame, cell_label,
                         first_daughter_frame))
                 is_valid = False
+                continue  # no need to test further
 
     if all_cells:  # all cells with lineages should be removed
         warnings.warn('Cells missing their lineage: {}'.format(

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -515,8 +515,8 @@ def is_valid_lineage(y, lineage):
 
         for daughter in cell_lineage['daughters']:
             if daughter not in lineage:
-                warnings.warn('lineage {} has invalid daughters: {}'.format(
-                    cell_label, cell_lineage['daughters']))
+                warnings.warn('Lineage {} has daughter {} not in lineage'.format(
+                    cell_label, daughter))
                 is_valid = False
                 continue  # no need to test further
 
@@ -530,8 +530,9 @@ def is_valid_lineage(y, lineage):
 
             # Check that daughter's start frame is one larger than parent end frame
             if first_daughter_frame - last_parent_frame != 1:
-                warnings.warn('lineage {} has daughter {} before parent.'.format(
-                    cell_label, daughter))
+                warnings.warn('Lineage {} has daughter {} in a '
+                              'non-subsequent frame.'.format(
+                                  cell_label, daughter))
                 is_valid = False
                 continue  # no need to test further
 

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -401,6 +401,17 @@ class TestTrackingUtils(object):
         bad_lineage[daughter_labels[0]]['frames'] = []
         assert not utils.is_valid_lineage(movie, bad_lineage)
 
+        # parent ID > daughters ID is OK
+        new_parent = max(np.unique(movie)) + 2
+        relabeled_movie = np.where(movie == parent_label, new_parent, movie)
+        relabeled_lineage = copy.deepcopy(lineage)
+        relabeled_lineage[new_parent] = lineage[parent_label]
+        del relabeled_lineage[parent_label]
+        for daughter in relabeled_lineage[new_parent]['daughters']:
+            if relabeled_lineage[daughter]['parent'] == parent_label:
+                relabeled_lineage[daughter]['parent'] = new_parent
+        assert utils.is_valid_lineage(relabeled_movie, relabeled_lineage)
+
     def test_get_image_features(self):
         num_labels = 3
         y = get_annotated_image(num_labels=num_labels, sequential=True)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
     readme = f.read()
 
 
-VERSION = '0.5.3'
+VERSION = '0.5.4'
 NAME = 'DeepCell_Tracking'
 DESCRIPTION = 'Tracking cells and lineage with deep learning.'
 LICENSE = 'LICENSE'


### PR DESCRIPTION
No need to check if the daughters are in `all_cells`, as we check that for each lineage. Just check that the daughter is in the lineage.

Don't return False as a shortcut, just warn and continue to the next label. This will enable all warnings to be shown.