### PR TITLE
Add additional metrics to report in classify_divisions

### DIFF
--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -407,7 +407,7 @@ def benchmark_division_performance(trk_gt, trk_res, path_gt=None, path_res=None)
     return div_results
 
 
-def calculate_summary_stats(true_positive, false_positive, false_negative, total_divisions):
+def calculate_summary_stats(true_positive, false_positive, false_negative, total_divisions, n_digits=2):
     """Calculate additional summary statistics for tracking performance
     based on results of classify_divisions
 
@@ -418,7 +418,10 @@ def calculate_summary_stats(true_positive, false_positive, false_negative, total
         false_positive (int): False positives
         false_negative (int): False negatives
         total_divisions (int): Total number of ground truth divisions
+        n_digits (int, optional): Number of digits to round to. Default 2.
     """
+
+    _round = lambda x: round(x, n_digits)
 
     try:
         recall = true_positive / (true_positive + false_negative)
@@ -446,9 +449,9 @@ def calculate_summary_stats(true_positive, false_positive, false_negative, total
         fraction_miss = 0
 
     return {
-        'recall': recall,
-        'precision': precision,
-        'F1': f1,
-        'mitotic branching correctness': mbc,
-        'fraction missed divisions': fraction_miss
+        'Recall': _round(recall),
+        'Precision': _round(precision),
+        'F1': _round(f1),
+        'Mitotic branching correctness': _round(mbc),
+        'Fraction missed divisions': _round(fraction_miss)
     }

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -407,7 +407,11 @@ def benchmark_division_performance(trk_gt, trk_res, path_gt=None, path_res=None)
     return div_results
 
 
-def calculate_summary_stats(true_positive, false_positive, false_negative, total_divisions, n_digits=2):
+def calculate_summary_stats(true_positive,
+                            false_positive,
+                            false_negative,
+                            total_divisions,
+                            n_digits=2):
     """Calculate additional summary statistics for tracking performance
     based on results of classify_divisions
 

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -351,23 +351,12 @@ def classify_divisions(G_gt, G_res):
     # Count any remaining res nodes as false positives
     false_positive += len(div_res)
 
-    # Calculate additional stats
-    recall = correct / (correct + missed)
-    precision = correct / (correct + false_positive)
-    f1 = 2 * (recall * precision) / (recall + precision)
-    mbc = correct / (correct + missed + false_positive)
-    total_miss = (missed + false_positive) / len(div_gt)
-
     return {
         'Correct division': correct,
         'Mismatch division': incorrect,
         'False positive division': false_positive,
         'False negative division': missed,
-        'Recall': recall,
-        'Precision': precision,
-        'F1': f1,
-        'Mitotic Branching Correctness': mbc,
-        'Total missed divisions': total_miss
+        'Total divisions': len(div_gt)
     }
 
 
@@ -416,3 +405,50 @@ def benchmark_division_performance(trk_gt, trk_res, path_gt=None, path_res=None)
     div_results = classify_divisions(G_gt, G_res)
 
     return div_results
+
+
+def calculate_summary_stats(true_positive, false_positive, false_negative, total_divisions):
+    """Calculate additional summary statistics for tracking performance
+    based on results of classify_divisions
+
+    Catch ZeroDivisionError and set to 0 instead
+
+    Args:
+        true_positive (int): True positive or "correct divisions"
+        false_positive (int): False positives
+        false_negative (int): False negatives
+        total_divisions (int): Total number of ground truth divisions
+    """
+
+    try:
+        recall = true_positive / (true_positive + false_negative)
+    except ZeroDivisionError:
+        recall = 0
+
+    try:
+        precision = true_positive / (true_positive + false_positive)
+    except ZeroDivisionError:
+        precision = 0
+
+    try:
+        f1 = 2 * (recall * precision) / (recall + precision)
+    except ZeroDivisionError:
+        f1 = 0
+
+    try:
+        mbc = true_positive / (true_positive + false_negative + false_positive)
+    except ZeroDivisionError:
+        mbc = 0
+
+    try:
+        fraction_miss = (false_negative + false_positive) / total_divisions
+    except ZeroDivisionError:
+        fraction_miss = 0
+
+    return {
+        'recall': recall,
+        'precision': precision,
+        'F1': f1,
+        'mitotic branching correctness': mbc,
+        'fraction missed divisions': fraction_miss
+    }

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -351,11 +351,23 @@ def classify_divisions(G_gt, G_res):
     # Count any remaining res nodes as false positives
     false_positive += len(div_res)
 
+    # Calculate additional stats
+    recall = correct / (correct + missed)
+    precision = correct / (correct + false_positive)
+    f1 = 2 * (recall * precision) / (recall + precision)
+    mbc = correct / (correct + missed + false_positive)
+    total_miss = (missed + false_positive) / len(div_gt)
+
     return {
         'Correct division': correct,
-        'Incorrect division': incorrect,
+        'Mismatch division': incorrect,
         'False positive division': false_positive,
-        'False negative division': missed
+        'False negative division': missed,
+        'Recall': recall,
+        'Precision': precision,
+        'F1': f1,
+        'Mitotic Branching Correctness': mbc,
+        'Total missed divisions': total_miss
     }
 
 
@@ -396,11 +408,11 @@ def benchmark_division_performance(trk_gt, trk_res, path_gt=None, path_res=None)
         # node_key maps gt nodes onto resnodes so must be applied to gt
         G_res = isbi_to_graph(res, node_key=node_key)
         G_gt = isbi_to_graph(gt)
-        div_results = classify_divisions(G_gt, G_res)
     else:
         node_key = {g: r for g, r in zip(cells_gt, cells_res)}
         G_res = isbi_to_graph(res)
         G_gt = isbi_to_graph(gt, node_key=node_key)
-        div_results = classify_divisions(G_gt, G_res)
+
+    div_results = classify_divisions(G_gt, G_res)
 
     return div_results

--- a/deepcell_tracking/isbi_utils_test.py
+++ b/deepcell_tracking/isbi_utils_test.py
@@ -184,7 +184,7 @@ class TestIsbiUtils(object):
         assert stats['False positive division'] == 1  # node 1_3
         assert stats['False negative division'] == 1  # node 4_3
         assert stats['Mismatch division'] == 1  # node 3_3
-        assert stats['Total divisions'] == 2
+        assert stats['Total divisions'] == 3
 
     def test_contig_tracks(self):
         # test already contiguous

--- a/deepcell_tracking/isbi_utils_test.py
+++ b/deepcell_tracking/isbi_utils_test.py
@@ -183,7 +183,8 @@ class TestIsbiUtils(object):
         assert stats['Correct division'] == 1  # the only correct one
         assert stats['False positive division'] == 1  # node 1_3
         assert stats['False negative division'] == 1  # node 4_3
-        assert stats['Incorrect division'] == 1  # node 3_3
+        assert stats['Mismatch division'] == 1  # node 3_3
+        assert stats['Total divisions'] == 2
 
     def test_contig_tracks(self):
         # test already contiguous
@@ -326,7 +327,8 @@ class TestIsbiUtils(object):
                 trks.add(tracked.name, 'tracked.npy')
                 os.remove(tracked.name)
 
-        expected = {'Correct division': 1, 'Incorrect division': 0,
-                    'False positive division': 0, 'False negative division': 0}
+        expected = {'Correct division': 1, 'Mismatch division': 0,
+                    'False positive division': 0, 'False negative division': 0,
+                    'Total divisions': 1}
         results = isbi_utils.benchmark_division_performance(trk_gt, trk_res)
         assert results == expected

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
     readme = f.read()
 
 
-VERSION = '0.5.5'
+VERSION = '0.5.6rc'
 NAME = 'DeepCell_Tracking'
 DESCRIPTION = 'Tracking cells and lineage with deep learning.'
 LICENSE = 'LICENSE'

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
     readme = f.read()
 
 
-VERSION = '0.5.6rc'
+VERSION = '0.5.6'
 NAME = 'DeepCell_Tracking'
 DESCRIPTION = 'Tracking cells and lineage with deep learning.'
 LICENSE = 'LICENSE'


### PR DESCRIPTION
Addresses #91 and bumps version to 0.5.6 for the next patch release after this PR is complete. I tested the new functionality in the model-registry and those updates can be seen in this branch: https://github.com/vanvalenlab/model-registry/compare/mrgn/tracking-evaluation. I added rounding after running this test, but decimals will now be truncated to 2 digits.