### PR TITLE
Enable option for fixed size crops in get_image_features

### DIFF
--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -650,7 +650,7 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
             appearances[i] = appearance
 
         if crop_mode == 'fixed':
-            cent = np.array(prop_padded.centroid)
+            cent = np.array(prop.centroid)
             delta = appearance_dim // 2
             minr = int(cent[0]) - delta
             maxr = int(cent[0]) + delta

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -656,8 +656,8 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
             minc = int(cent[1]) - delta
             maxc = int(cent[1]) + delta
 
-            app = np.copy(Xbt[minr:maxr, minc:maxc, :])
-            label = np.copy(ybt[minr:maxr, minc:maxc])
+            app = np.copy(X_padded[minr:maxr, minc:maxc, :])
+            label = np.copy(y_padded[minr:maxr, minc:maxc])
 
             # Use label as a mask to zero out non-label information
             app = app * (label == prop.label)

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -612,8 +612,7 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
                             appearance_dim, X.shape[-1]), dtype='float32')
 
     # Zero-pad the X array for fixed crop mode
-    pad_width = ((0, 0),
-                 (appearance_dim, appearance_dim),
+    pad_width = ((appearance_dim, appearance_dim),
                  (appearance_dim, appearance_dim),
                  (0, 0))
     X_padded = np.pad(X, pad_width=pad_width)

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -624,7 +624,7 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
     # iterate over all objects in y
     props = regionprops(y[..., 0], cache=False)
 
-    for i, (prop, prop_padded) in enumerate(zip(props, props_padded)):
+    for i, prop in enumerate(props):
 
         # Get label
         labels[i] = prop.label

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -658,12 +658,12 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
             app = np.copy(X_padded[minr:maxr, minc:maxc, :])
             label = np.copy(y_padded[minr:maxr, minc:maxc])
 
-            # Use label as a mask to zero out non-label information
-            app = app * (label == prop.label)
-            idx = np.nonzero(app)
-
-            # Check data and normalize
             if norm:
+                # Use label as a mask to zero out non-label information
+                app = app * (label == prop.label)
+                idx = np.nonzero(app)
+
+                # Check data and normalize
                 if len(idx) > 0:
                     mean = np.mean(app[np.nonzero(app)])
                     std = np.std(app[np.nonzero(app)])

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -611,12 +611,15 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
     appearances = np.zeros((num_labels, appearance_dim,
                             appearance_dim, X.shape[-1]), dtype='float32')
 
-    # Zero-pad the X array for fixed crop mode
-    pad_width = ((appearance_dim, appearance_dim),
-                 (appearance_dim, appearance_dim),
-                 (0, 0))
-    X_padded = np.pad(X, pad_width=pad_width)
-    y_padded = np.pad(y, pad_width=pad_width)
+    if crop_mode == 'fixed':
+        # Zero-pad the X array for fixed crop mode
+        pad_width = ((appearance_dim, appearance_dim),
+                     (appearance_dim, appearance_dim),
+                     (0, 0))
+        X_padded = np.pad(X, pad_width=pad_width)
+        y_padded = np.pad(y, pad_width=pad_width)
+
+        props = regionprops(y_padded[..., 0], cache=False)
 
     # iterate over all objects in y
     props = regionprops(y[..., 0], cache=False)

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -591,6 +591,9 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
         appearance_dim (int): The resized shape of the appearance feature.
         crop_mode (str): Whether to do a fixed crop or to crop and resize
             to create the appearance features
+        norm (bool): Whether to remove non cell features and normalize the
+            foreground pixels by zero-meaning and dividing by the standard
+            deviation. Applies to fixed crop mode only.
 
     Returns:
         dict: A dictionary of feature names to np.arrays of shape

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -623,7 +623,6 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
 
     # iterate over all objects in y
     props = regionprops(y[..., 0], cache=False)
-    props_padded = regionprops(y_padded[..., 0], cache=False)
 
     for i, (prop, prop_padded) in enumerate(zip(props, props_padded)):
 

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -665,9 +665,9 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
 
                 # Check data and normalize
                 if len(idx) > 0:
-                    mean = np.mean(app[np.nonzero(app)])
-                    std = np.std(app[np.nonzero(app)])
-                    app[np.nonzero(app)] = (app[np.nonzero(app)] - mean) / std
+                    mean = np.mean(app[idx])
+                    std = np.std(app[idx])
+                    app[idx] = (app[idx] - mean) / std
 
             appearances[i] = app
 

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -622,7 +622,8 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
         props = regionprops(y_padded[..., 0], cache=False)
 
     # iterate over all objects in y
-    props = regionprops(y[..., 0], cache=False)
+    if crop_mode == 'resize':
+        props = regionprops(y[..., 0], cache=False)
 
     for i, prop in enumerate(props):
 

--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -610,10 +610,9 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
     morphologies = np.zeros((num_labels, 3), dtype='float32')
     appearances = np.zeros((num_labels, appearance_dim,
                             appearance_dim, X.shape[-1]), dtype='float32')
-   
+
     # Zero-pad the X array for fixed crop mode
     pad_width = ((0, 0),
-                 (0, 0),
                  (appearance_dim, appearance_dim),
                  (appearance_dim, appearance_dim),
                  (0, 0))

--- a/deepcell_tracking/utils_test.py
+++ b/deepcell_tracking/utils_test.py
@@ -448,6 +448,13 @@ class TestTrackingUtils(object):
         assert labels.shape == expected_shape
         np.testing.assert_array_equal(labels, np.array(list(range(1, num_labels + 1))))
 
+        # test appearance - fixed crop
+        features = utils.get_image_features(X, y, appearance_dim,
+                                            crop_mode='fixed', norm=True)
+        appearances = features['appearances']
+        expected_shape = (num_labels, appearance_dim, appearance_dim, X.shape[-1])
+        assert appearances.shape == expected_shape
+
     def test_trks_stats(self):
         # Test bad extension
         with pytest.raises(ValueError):


### PR DESCRIPTION
## What
Add a flag to get_image_features to allow for doing fixed sized crops rather than crop and resize.

## Why
Crop and resize removes information about cell size, which is useful for cell tracking and also learning dynamic representations of cell behavior.