### PR TITLE
Classify divisions that are +/- 1 frame as correct

### DIFF
--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -37,7 +37,7 @@ import pandas as pd
 
 # Imports for backwards compatibility
 from deepcell_tracking.utils import match_nodes, contig_tracks
-from deepcell_tracking.metrics import classify_divisions, calculate_summary_stats
+from deepcell_tracking.metrics import calculate_summary_stats
 from deepcell_tracking.metrics import benchmark_tracking_performance
 
 

--- a/deepcell_tracking/metrics.py
+++ b/deepcell_tracking/metrics.py
@@ -202,8 +202,8 @@ def correct_shifted_divisions(
     G = {'gt': G_gt, 'res': G_res}
 
     # Explicitly label nodes according to source
-    missed = ['gt-'+n for n in missed]
-    false_positive = ['res-'+n for n in false_positive]
+    missed = ['gt-' + n for n in missed]
+    false_positive = ['res-' + n for n in false_positive]
 
     # Convert to dictionary for lookup by frame
     d_missed, d_fp = {}, {}
@@ -216,10 +216,10 @@ def correct_shifted_divisions(
 
     frame_pairs = []
     for t in d_missed:
-        if t+1 in d_fp:
-            frame_pairs.append((t, t+1))
-        if t-1 in d_fp:
-            frame_pairs.append((t-1, t))
+        if t + 1 in d_fp:
+            frame_pairs.append((t, t + 1))
+        if t - 1 in d_fp:
+            frame_pairs.append((t - 1, t))
 
     # Convert to set to remove any duplicates
     frame_pairs = list(set(frame_pairs))
@@ -453,7 +453,11 @@ def calculate_summary_stats(correct_division,
 
 
 class TrackingMetrics:
-    def __init__(self, lineage_gt, y_gt, lineage_res, y_res, threshold=1, allow_division_shift=True):
+    def __init__(self,
+                 lineage_gt, y_gt,
+                 lineage_res, y_res,
+                 threshold=1,
+                 allow_division_shift=True):
         """Class to coordinate the benchmarking of a pair of trk files
 
         Args:

--- a/deepcell_tracking/metrics.py
+++ b/deepcell_tracking/metrics.py
@@ -178,6 +178,19 @@ def correct_shifted_divisions(
         G_gt, G_res,
         threshold):
     """Correct divisions errors that are shifted by a frame and should be counted as correct
+
+    Args:
+        missed (list): List of nodes classifed as a false negative division
+        false_positive (list): List of nodes classified as false positive division
+        correct (list): List of nodes where divisions were correctly assigned
+        y_gt (np.array): Y mask for the ground truth data
+        y_res (np.array): Y mask for the predicted data
+        G_gt (networkx.graph): Graph of the ground truth
+        G_res (networkx.graph): Graph of the results
+        threshold (float): Value between 0 and 1 used to determine matching cells using IoU
+
+    Returns:
+        dict: Dictionary of updated missed, false_positive and correct division lists
     """
 
     metrics = {

--- a/deepcell_tracking/metrics.py
+++ b/deepcell_tracking/metrics.py
@@ -65,6 +65,113 @@ def map_node(gt_node, G_res, cells_gt, cells_res):
         return gt_node
 
 
+def classify_divisions(G_gt, G_res, cells_gt=[], cells_res=[]):
+    """Compare two graphs and calculate the cell division confusion matrix.
+
+    WARNING: This function will only work if the labels underlying both
+    graphs are the same. E.G. the parents only match if the same label
+    splits in the same frame - but each movie isn't guaranteed to be labeled
+    in the same way (with the same order). Should be used with match_nodes
+
+    Args:
+        G_gt (networkx.Graph): Ground truth cell lineage graph.
+        G_res (networkx.Graph): Predicted cell lineage graph.
+        cells_gt (np.ndarray): List of ground truth cell ids from `match_nodes`
+        cells_res (np.ndarray): List of result cell ids from `match_nodes`
+
+    Returns:
+        dict: Diciontary of all division statistics
+
+    Raises:
+        ValueError: cells_gt and cells_res must be the same length
+    """
+    if len(cells_gt) != len(cells_res):
+        raise ValueError('cells_gt and cells_res must be the same length.')
+
+    def _map_node(gt_node):
+        return map_node(gt_node, G_res, cells_gt, cells_res)
+
+    # Identify nodes with parent attribute
+    div_gt = [node for node, d in G_gt.nodes(data=True)
+              if d.get('division', False)]
+    div_res = [node for node, d in G_res.nodes(data=True)
+               if d.get('division', False)]
+
+    correct = []         # Correct division
+    incorrect = []       # Wrong/mismatch division
+    missed = []          # Missed division
+
+    for node in div_gt:
+        idx = int(node.split('_')[0])
+        frame = int(node.split('_')[1])
+
+        # Check if the index is mapped onto a different results index
+        if idx in cells_gt:
+            for r_idx in cells_res[cells_gt == idx]:
+                # Check if node exists with the right frame
+                r_node = '{}_{}'.format(r_idx, frame)
+                if r_node in G_res.nodes:
+                    break  # Exit for loop since we found the right node
+            else:
+                # Node doesn't exist so count this division as missed
+                print('missed node {} division completely'.format(node))
+                missed.append(node)
+                continue  # move on to next node in div_gt
+        # Check if the node exists with same id in G_res
+        elif node in G_res.nodes:
+            r_node = node
+        # Node doesn't exist
+        else:
+            print('missed node {} division completely'.format(node))
+            missed.append(node)
+            continue  # move on to next node in div_gt
+
+        # If we found the results node, evaluate division result
+        # Get gt predecessors and successors for comparsion
+        # Map gt nodes onto results nodes if possible
+        pred_gt = [_map_node(n) for n in G_gt.pred[node]]
+        succ_gt = [_map_node(n) for n in G_gt.succ[node]]
+
+        # Check if res node was also called a division
+        if r_node in div_res:
+            # Get res predecessors and successor
+            pred_res = list(G_res.pred[r_node])
+            succ_res = list(G_res.succ[r_node])
+
+            # Parents and daughters are the same, perfect!
+            if (Counter(pred_gt) == Counter(pred_res) and
+                    Counter(succ_gt) == Counter(succ_res)):
+                correct.append(node)
+
+            else:  # what went wrong?
+                incorrect.append(node)
+                errors = ['out degree = {}'.format(G_res.out_degree(r_node))]
+                if Counter(succ_gt) != Counter(succ_res):
+                    errors.append('daughters mismatch')
+                if Counter(pred_gt) != Counter(pred_res):
+                    errors.append('parents mismatch')
+                if G_res.out_degree(r_node) == G_gt.out_degree(node):
+                    errors.append('gt and res degree equal')
+                print(node, '{}.'.format(', '.join(errors)))
+
+            div_res.remove(r_node)
+
+        else:  # valid division not in results, it was missed
+            print('missed node {} division completely'.format(node))
+            missed.append(node)
+
+    # Count any remaining res nodes as false positives
+    false_positive = div_res
+
+    return {
+        'correct_division': correct,
+        'mismatch_division': incorrect,
+        'false_positive_division': false_positive,
+        'false_negative_division': missed,
+        'total_divisions': len(div_gt)
+    }
+
+
 def calculate_association_accuracy(lineage_gt, lineage_res, cells_gt=[], cells_res=[]):
     """Calculate the association accuracy for each ground truth lineage
 
@@ -252,28 +359,21 @@ class TrackingMetrics:
                 they are off by a single frame. Default True.
         """
 
-        self.lineage = {'gt': lineage_gt, 'res': lineage_res}
-        self.y = {'gt': y_gt, 'res': y_res}
+        self.lineage_gt = lineage_gt
+        self.lineage_res = lineage_res
+        self.y_gt = y_gt
+        self.y_res = y_res
         self.threshold = threshold
+        self.allow_division_shift = allow_division_shift
 
         # Match up labels in GT to Results to allow for direct comparisons
         self.cells_gt, self.cells_res = match_nodes(y_gt, y_res, self.threshold)
 
         # Generate graphs without remapping nodes to avoid losing lineages
-        self.G = {'gt': trk_to_graph(lineage_gt), 'res': trk_to_graph(lineage_res)}
+        self.G_gt = trk_to_graph(lineage_gt)
+        self.G_res = trk_to_graph(lineage_res)
 
-        # Classify divison errors
-        self.classify_divisions()
 
-        if allow_division_shift:
-            self.correct_shifted_divisions()
-
-        # Calculate aa and te
-        self.aa_tp, self.aa_total = calculate_association_accuracy(
-            lineage_gt, lineage_res, self.cells_gt, self.cells_res)
-
-        self.te_tp, self.te_total = calculate_target_effectiveness(
-            lineage_gt, lineage_res, self.cells_gt, self.cells_res)
 
     @classmethod
     def from_trk_files(cls, trk_gt, trk_res, threshold=1, allow_division_shift=True):
@@ -290,95 +390,19 @@ class TrackingMetrics:
             allow_division_shift=allow_division_shift
         )
 
-    def classify_divisions(self):
-        """Compare two graphs and calculate the cell division confusion matrix.
+    def calculate_metrics(self):
+        # Classify divison errors
+        division_stats = classify_divisions(self.G_gt, self.G_res, cells_gt=self.cells_gt, cells_res=self.cells_res)
 
-        WARNING: This function will only work if the labels underlying both
-        graphs are the same. E.G. the parents only match if the same label
-        splits in the same frame - but each movie isn't guaranteed to be labeled
-        in the same way (with the same order). Should be used with match_nodes
+        if self.allow_division_shift:
+            self.correct_shifted_divisions()
 
-        Returns:
-            dict: Diciontary of all division statistics
-        """
+        # Calculate aa and te
+        self.aa_tp, self.aa_total = calculate_association_accuracy(
+            self.lineage_gt, self.lineage_res, self.cells_gt, self.cells_res)
 
-        def _map_node(gt_node):
-            return map_node(gt_node, self.G['res'], self.cells_gt, self.cells_res)
-
-        # Identify nodes with parent attribute
-        div_gt = [node for node, d in self.G['gt'].nodes(data=True)
-                  if d.get('division', False)]
-        div_res = [node for node, d in self.G['res'].nodes(data=True)
-                   if d.get('division', False)]
-
-        # Record total number of gt divisions
-        self.total_divisions = len(div_gt)
-
-        self.correct = []         # Correct division
-        self.incorrect = []       # Wrong/mismatch division
-        self.missed = []          # Missed division
-
-        for node in div_gt:
-            idx = int(node.split('_')[0])
-            frame = int(node.split('_')[1])
-
-            # Check if the index is mapped onto a different results index
-            if idx in self.cells_gt:
-                for r_idx in self.cells_res[self.cells_gt == idx]:
-                    # Check if node exists with the right frame
-                    r_node = '{}_{}'.format(r_idx, frame)
-                    if r_node in self.G['res'].nodes:
-                        break  # Exit for loop since we found the right node
-                else:
-                    # Node doesn't exist so count this division as missed
-                    print('missed node {} division completely'.format(node))
-                    self.missed.append(node)
-                    continue  # move on to next node in div_gt
-            # Check if the node exists with same id in G_res
-            elif node in self.G['res'].nodes:
-                r_node = node
-            # Node doesn't exist
-            else:
-                print('missed node {} division completely'.format(node))
-                self.missed.append(node)
-                continue  # move on to next node in div_gt
-
-            # If we found the results node, evaluate division result
-            # Get gt predecessors and successors for comparsion
-            # Map gt nodes onto results nodes if possible
-            pred_gt = [_map_node(n) for n in self.G['gt'].pred[node]]
-            succ_gt = [_map_node(n) for n in self.G['gt'].succ[node]]
-
-            # Check if res node was also called a division
-            if r_node in div_res:
-                # Get res predecessors and successor
-                pred_res = list(self.G['res'].pred[r_node])
-                succ_res = list(self.G['res'].succ[r_node])
-
-                # Parents and daughters are the same, perfect!
-                if (Counter(pred_gt) == Counter(pred_res) and
-                        Counter(succ_gt) == Counter(succ_res)):
-                    self.correct.append(node)
-
-                else:  # what went wrong?
-                    self.incorrect.append(node)
-                    errors = ['out degree = {}'.format(self.G['res'].out_degree(r_node))]
-                    if Counter(succ_gt) != Counter(succ_res):
-                        errors.append('daughters mismatch')
-                    if Counter(pred_gt) != Counter(pred_res):
-                        errors.append('parents mismatch')
-                    if self.G['res'].out_degree(r_node) == self.G['gt'].out_degree(node):
-                        errors.append('gt and res degree equal')
-                    print(node, '{}.'.format(', '.join(errors)))
-
-                div_res.remove(r_node)
-
-            else:  # valid division not in results, it was missed
-                print('missed node {} division completely'.format(node))
-                self.missed.append(node)
-
-        # Count any remaining res nodes as false positives
-        self.false_positive = div_res
+        self.te_tp, self.te_total = calculate_target_effectiveness(
+            self.lineage_gt, self.lineage_res, self.cells_gt, self.cells_res)
 
     def correct_shifted_divisions(self):
         """Correct divisions errors that are shifted by a frame and should be counted as correct

--- a/deepcell_tracking/metrics_test.py
+++ b/deepcell_tracking/metrics_test.py
@@ -74,10 +74,10 @@ def test_classify_divisions():
 
     stats = metrics.classify_divisions(G, H)
 
-    assert stats['correct_division'] == 1  # the only correct one
-    assert stats['false_positive_division'] == 1  # node 1_3
-    assert stats['false_negative_division'] == 1  # node 4_3
-    assert stats['mismatch_division'] == 1  # node 3_3
+    assert len(stats['correct_division']) == 1  # the only correct one
+    assert len(stats['false_positive_division']) == 1  # node 1_3
+    assert len(stats['false_negative_division']) == 1  # node 4_3
+    assert len(stats['mismatch_division']) == 1  # node 3_3
     assert stats['total_divisions'] == 3
 
     # lists must be the same length
@@ -90,10 +90,10 @@ def test_classify_divisions():
     H_renamed = nx.relabel_nodes(H, node_key)
 
     stats = metrics.classify_divisions(G, H_renamed, cells_gt=cells_gt, cells_res=cells_res)
-    assert stats['correct_division'] == 1  # the only correct one
-    assert stats['false_positive_division'] == 1  # node 1_3
-    assert stats['false_negative_division'] == 1  # node 4_3
-    assert stats['mismatch_division'] == 1  # node 3_3
+    assert len(stats['correct_division']) == 1  # the only correct one
+    assert len(stats['false_positive_division']) == 1  # node 1_3
+    assert len(stats['false_negative_division']) == 1  # node 4_3
+    assert len(stats['mismatch_division']) == 1  # node 3_3
     assert stats['total_divisions'] == 3
 
 

--- a/deepcell_tracking/test_utils.py
+++ b/deepcell_tracking/test_utils.py
@@ -119,7 +119,7 @@ def generate_division_data(img_size=256):
 
     # Generate parent frame
     im = np.zeros((img_size, img_size))
-    parent = np.random.randint(low=img_size*0.25, high=img_size*0.75, size=(2,))
+    parent = np.random.randint(low=img_size * 0.25, high=img_size * 0.75, size=(2,))
     im[parent[0], parent[1]] = 1
     im = sk.filters.gaussian(im, sigma=5)
     parent_label = sk.measure.label(im > 0.7 * im.mean())
@@ -128,7 +128,7 @@ def generate_division_data(img_size=256):
 
     # Calculate position of daughters in the first frame
     width = sk.measure.regionprops(parent_label)[0].axis_minor_length
-    shift = int(width/3)
+    shift = int(width / 3)
     d1 = [parent[0] - shift, parent[1]]
     d2 = [parent[0] + shift, parent[1]]
 


### PR DESCRIPTION
Recent reviews of tracking predictions have identified a failure mode in the current metrics packages. Different segmentation predictions can sometimes lead to a cell dividing in one frame before or after the frame assigned to the division in the ground truth. Currently this leads to that division counting as both a false positive and a missed division. This PR introduces a new metrics function that identifies these events and corrects the metrics to classify this division as correct. Additionally a new metrics class for tracking (`TrackingMetrics`) has been introduced to coordinate running all of the necessary metrics functions.

In the current test split, applying the new metrics pipeline led to the following changes in metrics:
| Metric                        | Old  | New  |
|-------------------------------|------|------|
| Total divisions               | 181  | 181  |
| Correct divisions             | 139  | 154  |
| False negative division       | 27   | 13   |
| False positive division       | 40   | 26   |
| Mismatch division             | 15   | 14   |
| Division Recall               | 0.84 | 0.92 |
| Division Precision            | 0.78 | 0.86 |
| Division F1                   | 0.81 | 0.89 |
| Mitotic branching correctness | 0.67 | 0.8  |
| Fraction missed divisions     | 0.15 | 0.07 |