### PR TITLE
Correct keys in correct_shifted_divisions

### DIFF
--- a/deepcell_tracking/metrics.py
+++ b/deepcell_tracking/metrics.py
@@ -190,7 +190,8 @@ def correct_shifted_divisions(
         threshold (float): Value between 0 and 1 used to determine matching cells using IoU
 
     Returns:
-        dict: Dictionary of updated false_negative_division, false_positive_division and correct_division lists
+        dict: Dictionary of updated false_negative_division, false_positive_division
+            and correct_division lists
     """
 
     metrics = {
@@ -207,7 +208,8 @@ def correct_shifted_divisions(
 
     # Convert to dictionary for lookup by frame
     d_false_negative_division, d_fp = {}, {}
-    for d, l in [(d_false_negative_division, false_negative_division), (d_fp, false_positive_division)]:
+    for d, l in [(d_false_negative_division, false_negative_division),
+                 (d_fp, false_positive_division)]:
         for n in l:
             t = int(n.split('_')[-1])
             v = d.get(t, [])

--- a/deepcell_tracking/metrics_test.py
+++ b/deepcell_tracking/metrics_test.py
@@ -116,7 +116,7 @@ def test_correct_shifted_divisions():
         0.6)
 
     # Check corrections
-    assert len(corrected['correct']) == 1
+    assert len(corrected['correct_division']) == 1
     assert len(stats['false_positive_division']) == 0
     assert len(stats['false_negative_division']) == 0
 
@@ -135,7 +135,7 @@ def test_correct_shifted_divisions():
         0.6)
 
     # Check corrections
-    assert len(corrected['correct']) == 1
+    assert len(corrected['correct_division']) == 1
     assert len(stats['false_positive_division']) == 0
     assert len(stats['false_negative_division']) == 0
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
     readme = f.read()
 
 
-VERSION = '0.6.2'
+VERSION = '0.6.3'
 NAME = 'DeepCell_Tracking'
 DESCRIPTION = 'Tracking cells and lineage with deep learning.'
 LICENSE = 'LICENSE'


### PR DESCRIPTION
Different key names were used in `correct_shifted_divisions` which caused issues in some downstream analyses in the model-registry. This PR standardizes all keys in the metrics package to avoid confusion.