### PR TITLE
Add support for ISBI inputs to the metrics package

### DIFF
--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -170,6 +170,47 @@ def isbi_to_graph(df, node_key=None):
     return G
 
 
+def isbi_to_lineage(df):
+    """Converts an ISBI style dataframe to a lineage dictionary"""
+
+    lineage = {}
+    # First write basic lineages without divisions
+    for _, r in df.iterrows():
+        cell = r['Cell_ID']
+        frames = list(np.arange(r['Start'], r['End'] + 1))
+
+        lineage[cell] = {
+            "label": cell,
+            "frames": frames,
+            "daughters": [],
+            "capped": False,
+            "frame_div": None,
+            "parent": None,
+            }
+
+    # Add division information to parents and daughters
+    for _, r in df[df['Parent_ID'] != 0].iterrows():
+        daughter = r['Cell_ID']
+        parent = r['Parent_ID']
+
+        # Set parent of daughter
+        lineage[daughter]['parent'] = parent
+
+        # Set daughter and frame_div of parent
+        lineage[parent]['daughters'].append(daughter)
+        lineage[parent]['frame_div'] = max(lineage[parent]['frames'])
+
+    return lineage
+
+
+def txt_to_lineage(path):
+    names = ['Cell_ID', 'Start', 'End', 'Parent_ID']
+    df = pd.read_csv(path, header=None, sep=' ', names=names)
+    lineage = isbi_to_lineage(df)
+
+    return lineage
+
+
 def load_tiffs(data_dir):
     """Load a directory of individual frames into a stack"""
     ims = []

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -37,19 +37,6 @@ import numpy as np
 import pandas as pd
 from tifffile import imread
 
-# Imports for backwards compatibility
-from deepcell_tracking.utils import match_nodes, contig_tracks
-from deepcell_tracking.metrics import calculate_summary_stats
-from deepcell_tracking.metrics import benchmark_tracking_performance
-
-
-def benchmark_division_performance(trk_gt, trk_res):
-    warnings.warn('benchmark_division_performance is deprecated. '
-                  'Please use deepcell_tracking.metrics.benchmark_tracking_performance instead',
-                  DeprecationWarning)
-
-    return benchmark_tracking_performance(trk_gt, trk_res)
-
 
 def trk_to_isbi(track, path=None):
     """Convert a lineage track into an ISBI formatted text file.

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -29,11 +29,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import glob
 import warnings
 
 import networkx as nx
 import numpy as np
 import pandas as pd
+from tifffile import imread
 
 # Imports for backwards compatibility
 from deepcell_tracking.utils import match_nodes, contig_tracks
@@ -179,3 +181,13 @@ def isbi_to_graph(df, node_key=None):
     for cell_id in single_nodes:
         G.add_node(cell_id)
     return G
+
+
+def load_tiffs(data_dir):
+    """Load a directory of individual frames into a stack"""
+    ims = []
+    for f in np.sort(glob.glob(f'{data_dir}/*.tif')):
+        ims.append(imread(f))
+
+    mov = np.stack(ims)
+    return mov

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -186,7 +186,7 @@ def isbi_to_lineage(df):
             "capped": False,
             "frame_div": None,
             "parent": None,
-            }
+        }
 
     # Add division information to parents and daughters
     for _, r in df[df['Parent_ID'] != 0].iterrows():

--- a/deepcell_tracking/isbi_utils.py
+++ b/deepcell_tracking/isbi_utils.py
@@ -177,4 +177,5 @@ def load_tiffs(data_dir):
         ims.append(imread(f))
 
     mov = np.stack(ims)
+    mov = np.expand_dims(mov, axis=-1)
     return mov

--- a/deepcell_tracking/isbi_utils_test.py
+++ b/deepcell_tracking/isbi_utils_test.py
@@ -150,3 +150,29 @@ class TestIsbiUtils(object):
                     assert G.has_edge(parent_id, daughter_id)
                 else:
                     assert not G.in_degree(daughter_id)
+
+    def test_isbi_to_lineage(self):
+        data = [{'Cell_ID': 1, 'Start': 0, 'End': 3, 'Parent_ID': 0},
+                {'Cell_ID': 2, 'Start': 0, 'End': 2, 'Parent_ID': 0},
+                {'Cell_ID': 3, 'Start': 3, 'End': 3, 'Parent_ID': 2},
+                {'Cell_ID': 4, 'Start': 3, 'End': 3, 'Parent_ID': 2},
+                {'Cell_ID': 5, 'Start': 3, 'End': 3, 'Parent_ID': 4}]
+        divisions = [{'parent': 2, 'daughters': [3, 4]}]
+
+        df = pd.DataFrame(data)
+        lineage = isbi_utils.isbi_to_lineage(df)
+
+        # Check frames for each cell
+        for d in data:
+            frames = lineage[d['Cell_ID']]['frames']
+            assert d['Start'] == min(frames)
+            assert d['End'] == max(frames)
+
+        # Check divisions
+        for div in divisions:
+            for d in div['daughters']:
+                # Check that parent has daughters
+                assert d in lineage[div['parent']]['daughters']
+
+                # Check that daughter has parent
+                assert div['parent'] == lineage[d]['parent']

--- a/deepcell_tracking/metrics.py
+++ b/deepcell_tracking/metrics.py
@@ -35,9 +35,9 @@ import os
 
 import numpy as np
 
-from deepcell_tracking.isbi_utils import load_tiffs, txt_to_graph
 from deepcell_tracking.trk_io import load_trks
 from deepcell_tracking.utils import match_nodes, trk_to_graph
+from deepcell_tracking.isbi_utils import load_tiffs, txt_to_lineage
 
 
 def map_node(gt_node, G_res, cells_gt, cells_res):
@@ -458,15 +458,15 @@ def calculate_summary_stats(correct_division,
 
 class TrackingMetrics:
     def __init__(self,
-                 G_gt, G_res,
-                 y_gt, y_res,
+                 lineage_gt, y_gt,
+                 lineage_res, y_res,
                  threshold=1,
                  allow_division_shift=True):
         """Class to coordinate the benchmarking of a pair of trk files
 
         Args:
-            G_gt (networkx.Graph): Ground truth cell lineage graph.
-            G_res (networkx.Graph): Predicted cell lineage graph.
+            lineage_gt (dict): Ground truth lineages
+            linage_res (dict): Predicted lineages
             y_gt (np.array): Y mask for the ground truth data
             y_res (np.array): Y mask for the predicted data
             threshold (optional, float): threshold value for IoU to count as same cell. Default 1.
@@ -475,8 +475,9 @@ class TrackingMetrics:
             allow_division_shift (optional, bool): Allows divisions to be treated as correct if
                 they are off by a single frame. Default True.
         """
-        self.G_gt = G_gt
-        self.G_res = G_res
+
+        self.lineage_gt = lineage_gt
+        self.lineage_res = lineage_res
         self.y_gt = y_gt
         self.y_res = y_res
         self.threshold = threshold
@@ -485,6 +486,10 @@ class TrackingMetrics:
         # Match up labels in GT to Results to allow for direct comparisons
         self.cells_gt, self.cells_res = match_nodes(y_gt, y_res, self.threshold)
 
+        # Generate graphs without remapping nodes to avoid losing lineages
+        self.G_gt = trk_to_graph(lineage_gt)
+        self.G_res = trk_to_graph(lineage_res)
+
         self.stats = self.calculate_metrics()
 
     @classmethod
@@ -492,15 +497,12 @@ class TrackingMetrics:
         # Load data
         trks = load_trks(trk_gt)
         lineage_gt, y_gt = trks['lineages'][0], trks['y']
-        G_gt = trk_to_graph(lineage_gt)
-
         trks = load_trks(trk_res)
         lineage_res, y_res = trks['lineages'][0], trks['y']
-        G_res = trk_to_graph(lineage_res)
 
         return cls(
-            G_gt=G_gt, G_res=G_res,
-            y_gt=y_gt, y_res=y_res,
+            lineage_gt=lineage_gt, y_gt=y_gt,
+            lineage_res=lineage_res, y_res=y_res,
             threshold=threshold,
             allow_division_shift=allow_division_shift
         )
@@ -514,14 +516,14 @@ class TrackingMetrics:
                        res_txt_file='res_track.txt'):
         # Load data
         y_gt = load_tiffs(dir_gt)
-        G_gt = txt_to_graph(os.path.join(dir_gt, gt_txt_file))
+        lineage_gt = txt_to_lineage(os.path.join(dir_gt, gt_txt_file))
 
         y_res = load_tiffs(dir_res)
-        G_res = txt_to_graph(os.path.join(dir_res, res_txt_file))
+        lineage_res = txt_to_lineage(os.path.join(dir_res, res_txt_file))
 
         return cls(
-            G_gt=G_gt, G_res=G_res,
-            y_gt=y_gt, y_res=y_res,
+            lineage_gt=lineage_gt, y_gt=y_gt,
+            lineage_res=lineage_res, y_res=y_res,
             threshold=threshold,
             allow_division_shift=allow_division_shift
         )


### PR DESCRIPTION
This addition to the metrics package makes it possible to directly input ISBI style outputs into our metrics pipeline. This simplifies the process of benchmarking against competitor models which tend to output ISBI style tracks.