### PR TITLE
REL: pin numpy and update deepcell-toolbox dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
     readme = f.read()
 
 
-VERSION = '0.6.3'
+VERSION = '0.6.4'
 NAME = 'DeepCell_Tracking'
 DESCRIPTION = 'Tracking cells and lineage with deep learning.'
 LICENSE = 'LICENSE'
@@ -61,7 +61,7 @@ setup(name=NAME,
                         'pandas',
                         'scipy',
                         'scikit-image>=0.14.5',
-                        'deepcell-toolbox~=0.11.2'
+                        'deepcell-toolbox~=0.12.0'
                         ],
       extras_require={
           'tests': ['pytest<6',


### PR DESCRIPTION
A patch release to upper-bound numpy to prevent errors related to expired scalar deprecations. Bumps the `deepcell-toolbox` dependency as well, which already has more comprehensive fixes for this issue.