### PR TITLE
Cast data to correct type in `get_image_features`

### DIFF
--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -426,6 +426,9 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
         dict: A dictionary of feature names to np.arrays of shape
             (n, c) or (n, x, y, c) where n is the number of objects.
     """
+    # X must be float32 for the resize norm option to work correctly
+    X = X.astype('float32')
+    y = y.astype('int32')
 
     if crop_mode not in ['resize', 'fixed']:
         raise ValueError('crop_mode must be either resize or fixed')


### PR DESCRIPTION
This PR fixes a bug in `get_image_features`. If the X data is passed in with an integer type (instead of float), the output of `crop_mode='fixed'` and `norm=True` is incorrect. In the examples below, the first image is incorrect while the second is correct.

This PR eliminates the bug by casting X data to float32 and y data to int32 to avoid incorrect use of the function.

<img width="420" alt="Screen Shot 2023-01-24 at 7 34 48 PM" src="https://user-images.githubusercontent.com/20373588/214474471-a4a41fe9-4e58-44a5-8986-2001c0827822.png">
<img width="439" alt="Screen Shot 2023-01-24 at 7 34 38 PM" src="https://user-images.githubusercontent.com/20373588/214474468-1c6ecc00-ec06-4ec6-821b-e5b67b5e9012.png">

