### PR TITLE
Reuse indexed array to avoid extra array copies.

### DIFF
--- a/deepcell_tracking/utils.py
+++ b/deepcell_tracking/utils.py
@@ -498,9 +498,10 @@ def get_image_features(X, y, appearance_dim=32, crop_mode='resize', norm=True):
 
                 # Check data and normalize
                 if len(idx) > 0:
-                    mean = np.mean(app[idx])
-                    std = np.std(app[idx])
-                    app[idx] = (app[idx] - mean) / std
+                    masked_app = app[idx]
+                    mean = np.mean(masked_app)
+                    std = np.std(masked_app)
+                    app[idx] = (masked_app - mean) / std
 
             appearances[i] = app
 


### PR DESCRIPTION
A minor change that should improve performance. Unfortunately NumPy isn't smart enough to cache indexing results for reuse, so each `app[idx]` invocation of advanced indexing is actually creating a new array (as opposed to a view), resulting in both more memory usage and additional computation time for each allocation. There should be a significant performance boost by only performing the advanced indexing operation once and reusing the result.

Not critically important - just something I noticed while reviewing #114! 