### PR TITLE
Update action for deploying to pypi

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -13,15 +13,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.10'
 
     - name: Build a source distribution
-      run: python setup.py sdist
+      run: |
+        python -m pip install --upgrade setuptools wheel
+        python setup.py sdist
 
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
 - Pin Python version to 3.10
 - Explicitly add setuptools and wheel to build env
 - Bump action versions